### PR TITLE
json schema support array type

### DIFF
--- a/modelscope_agent/tools/base.py
+++ b/modelscope_agent/tools/base.py
@@ -218,6 +218,8 @@ class BaseTool(ABC):
                     'description':
                     para['description']
                 }
+                if 'type' in para and para['type'] == 'array':
+                    function_details['items'] = para['items']
                 if 'enum' in para and para['enum'] not in ['', []]:
                     function_details['enum'] = para['enum']
                 function['parameters']['properties'][


### PR DESCRIPTION
oai json schema support array type, fix the following bug:
`Error code: 400 - {'error': {'message': "Invalid schema for function 'get_room_layout': In context=('properties', 'objects'), array schema missing items.", 'type': 'invalid_request_error', 'param': 'tools[0].function.parameters', 'code': 'invalid_function_parameters'}} `