### PR TITLE
Bug fix 650: handle incorrect argument count in Plan.replace_task

### DIFF
--- a/modelscope_agent/schemas.py
+++ b/modelscope_agent/schemas.py
@@ -164,28 +164,56 @@ class Plan(BaseModel):
             task = self.task_map[task_id]
             task.reset()
 
-    def replace_task(self, new_task: Task):
+    def replace_task(self, task, decomposed_tasks=None):
         """
-        Replace an existing task with the new input task based on task_id, and reset all tasks depending on it.
+        Replace an existing task with a new task or a list of decomposed tasks.
 
         Args:
-            new_task (Task): The new task that will replace an existing one.
+            task (Task): The original task to be replaced.
+            decomposed_tasks (List[Task], optional): A list of tasks to replace the original one.
+                If not provided, this behaves like the original `replace_task(new_task)`.
 
         Returns:
             None
         """
-        assert new_task.task_id in self.task_map
-        # Replace the task in the task map and the task list
-        self.task_map[new_task.task_id] = new_task
-        for i, task in enumerate(self.tasks):
-            if task.task_id == new_task.task_id:
-                self.tasks[i] = new_task
-                break
+        if decomposed_tasks is None:
+            assert task.task_id in self.task_map, "Task ID not found in task_map"
+            self.task_map[task.task_id] = task
 
-        # Reset dependent tasks
-        for task in self.tasks:
-            if new_task.task_id in task.dependent_task_ids:
-                self.reset_task(task.task_id)
+            for i, t in enumerate(self.tasks):
+                if t.task_id == task.task_id:
+                    self.tasks[i] = task
+                    break
+
+            for t in self.tasks:
+                if task.task_id in t.dependent_task_ids:
+                    self.reset_task(t.task_id)
+
+        else:
+            original_task_id = task.task_id
+            assert original_task_id in self.task_map, "Original task ID not found in task_map"
+
+            index = -1
+            for i, t in enumerate(self.tasks):
+                if t.task_id == original_task_id:
+                    index = i
+                    break
+            if index == -1:
+                raise ValueError("Original task not found in tasks list")
+
+            self.tasks.pop(index)
+
+            self.tasks[index:index] = decomposed_tasks
+
+            del self.task_map[original_task_id]
+            for t in decomposed_tasks:
+                self.task_map[t.task_id] = t
+
+            self.current_task_id = decomposed_tasks[0].task_id
+
+            for t in self.tasks:
+                if original_task_id in t.dependent_task_ids:
+                    self.reset_task(t.task_id)
 
     def append_task(self, new_task: Task):
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
- Fixed TypeError where Plan.replace_task() was called with 3 arguments instead of 2.
- Adjusted task replacement logic to ensure correct parameter passing.

## Related issue number
reference: https://github.com/modelscope/ms-agent/issues/650
fix #650
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [ ] Some cases need DASHSCOPE_TOKEN_API to pass the Unit Tests, I have at least **pass the Unit tests on local**
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
