### PR TITLE
fix(llm): prevent orphaned tool_calls and missing type field in continue-gen path

### DIFF
--- a/ms_agent/llm/deepseek_llm.py
+++ b/ms_agent/llm/deepseek_llm.py
@@ -37,7 +37,7 @@ class DeepSeek(OpenAI):
         messages = self.format_input_message(messages)
         stop = kwargs.pop('stop', []).append('```')
         return self._call_llm(
-            messages=messages, tools=tools, stop=stop, **kwargs)
+            messages=messages, tools=self.format_tools(tools), stop=stop, **kwargs)
 
 
 if __name__ == '__main__':

--- a/ms_agent/llm/openai_llm.py
+++ b/ms_agent/llm/openai_llm.py
@@ -499,7 +499,7 @@ class OpenAI(LLM):
             messages[-1].partial = True
         messages[-1].api_calls += 1
 
-        return self._call_llm(messages, tools, **kwargs)
+        return self._call_llm(messages, self.format_tools(tools), **kwargs)
 
     def _continue_generate(self,
                            messages: List[Message],

--- a/ms_agent/llm/openai_llm.py
+++ b/ms_agent/llm/openai_llm.py
@@ -343,9 +343,10 @@ class OpenAI(LLM):
                     # The stream may end without a final usage chunk, which is acceptable.
                     pass
                 first_run = not messages[-1].to_dict().get('partial', False)
-                if chunk.choices[0].finish_reason in [
+                if (not message.tool_calls
+                        and chunk.choices[0].finish_reason in [
                         'length', 'null'
-                ] and (max_runs is None or max_runs != 0):
+                ] and (max_runs is None or max_runs != 0)):
                     logger.info(
                         f'finish_reason: {chunk.choices[0].finish_reason}, continue generate.'
                     )
@@ -522,6 +523,8 @@ class OpenAI(LLM):
             Message: A fully formed Message object containing the complete response.
         """
         new_message = self._format_output_message(completion)
+        if new_message.tool_calls:
+            return new_message
         if completion.choices[0].finish_reason in [
                 'length', 'null'
         ] and (max_runs is None or max_runs != 0):


### PR DESCRIPTION
## Fix 1: Missing `type` field in continue-gen tool calls

**Problem:** `_call_llm_for_continue_gen` passes raw `Tool` TypedDicts directly to `_call_llm` without formatting first. The `Tool` TypedDict has no `type` field — it gets added by `format_tools()`. When a response hits `finish_reason: length` and enters the continue-generation path, the unformatted tools cause:

```
openai.BadRequestError: Error code: 400 - tools[0]: missing field `type`
```

**Fix:** Added `self.format_tools(tools)` in `_call_llm_for_continue_gen` in both `openai_llm.py` and `deepseek_llm.py`.

## Fix 2: Orphaned tool_calls causing "insufficient tool messages" error (fixes #909)

**Problem:** When `finish_reason: length` fires with `tool_calls` present in the truncated response, `_continue_generate` and `_stream_continue_generate` append the partial assistant message (containing tool_calls) to the message history, then immediately call the LLM for continuation without executing the tools. The resulting messages list has assistant `tool_calls` but no corresponding tool responses, causing:

```
openai.BadRequestError: insufficient tool messages following tool_calls message
```

This causes sub-agents (e.g., Reporter) to crash after 3 retries, leading to infinite re-spawn loops.

**Fix:** Return early when `tool_calls` are present, letting the normal `step()` tool-execution loop handle the truncated message:

- `_continue_generate` (line 526): `if new_message.tool_calls: return new_message`
- `_stream_continue_generate` (line 346): add `not message.tool_calls and` guard before the finish_reason continuation check

## Testing

Tested both fixes with `deepseek-v4-pro` on the `deep_research/v2` pipeline. Without the fixes, the pipeline reliably hits both errors. With both fixes applied, the pipeline completes without errors.