### PR TITLE
Fix bugs

### DIFF
--- a/ms_agent/agent_hub/_commands.py
+++ b/ms_agent/agent_hub/_commands.py
@@ -145,6 +145,19 @@ def build_spec(framework: str, name: str, local_dir=None) -> WorkspaceSpec:
     return spec_cls(agent_name=name, local_dir=local)
 
 
+def _existing_skill_names(paths) -> list[str]:
+    """Skill dir names already present on the target (``skills/<name>/...``).
+
+    Fed to ``merge_resources(existing_skills=...)`` so a cross-framework
+    convert / download never silently overwrites a skill the target already
+    has (BUG-024).
+    """
+    return sorted({
+        p.split('/')[1]
+        for p in paths if p.startswith('skills/') and p.count('/') >= 2
+    })
+
+
 def convert_resources(
     resources: dict,
     source_fw: str,
@@ -156,6 +169,7 @@ def convert_resources(
     dst_spec: WorkspaceSpec | None = None,
     fill_missing_defaults: bool = True,
     collect_merges: list[tuple[str, str]] | None = None,
+    collect_skips: list[str] | None = None,
 ) -> dict:
     """Convert workspace resources from one framework format to another.
 
@@ -192,9 +206,19 @@ def convert_resources(
         source_defaults=get_defaults(source_fw),
         target_defaults=get_defaults(target_fw),
         fill_missing_defaults=fill_missing_defaults,
+        overflow_target=(_file_per_agent_identity_path(dst_spec)
+                         if dst_spec is not None else None),
+        identity_source=(_file_per_agent_identity_path(src_spec)
+                         if src_spec is not None else None),
+        existing_skills=(_existing_skill_names(existing_files)
+                         if existing_files else None),
     )
     if collect_merges is not None:
         collect_merges.extend(merged_away_pairs(result))
+    if collect_skips is not None:
+        collect_skips.extend(
+            a.path for a in result.actions
+            if a.action == 'skip' and 'already exists' in a.detail)
     merged = result.merged_files
     if existing_files is not None:
         default_paths = {
@@ -323,8 +347,13 @@ def cmd_upload(
     # boilerplate is never pushed -- keeps upload and convert 1:1-consistent
     # about what "the user's own files" are.
     from ._sync import drop_unchanged_defaults, sanitize_outbound
-    resources = drop_unchanged_defaults(
-        sanitize_outbound(resources, spec), framework, spec)
+    try:
+        resources = drop_unchanged_defaults(
+            sanitize_outbound(resources, spec), framework, spec)
+    except ValueError as e:
+        # Fail-closed sanitize: a config file that cannot be parsed cannot be
+        # verified secret-free -- abort instead of pushing plaintext keys.
+        return _fail(str(e))
     if not resources:
         display_name = local_name if local_name != GLOBAL_AGENT_NAME else 'global'
         return _fail(
@@ -387,6 +416,24 @@ def cmd_upload(
     display.done(
         f'Synced {len(resources)} file(s) to {group}/{repo_n} (incremental)')
     return 0
+
+
+def _download_file(client, group: str, repo_n: str, path: str):
+    """Download one repo file byte-faithfully, decoding text when possible.
+
+    Always fetches raw bytes (``binary=True``): the default text mode decodes
+    the HTTP body with a guessed charset and re-encoding it corrupts binary
+    assets (skills/*/assets/*, openhuman wiki/assets/*.png -- a PNG's ``\\x89``
+    magic byte is not valid UTF-8).  Content that IS valid UTF-8 is returned
+    as ``str`` so the conversion / merge pipeline sees the same text values as
+    before; everything else stays ``bytes``, which convert passes through
+    verbatim and ``spec.apply`` writes to disk unchanged.
+    """
+    raw = client.download_repo_file(group, repo_n, path, binary=True)
+    try:
+        return raw.decode('utf-8')
+    except UnicodeDecodeError:
+        return raw
 
 
 def _remote_paths_for_agent(
@@ -569,8 +616,8 @@ def cmd_download(
             total = len(to_download)
             for i, f in enumerate(to_download, 1):
                 print(f'  [{i}/{total}] downloading {f.path}', flush=True)
-                resources[remote_map[f.path]] = client.download_repo_file(
-                    group, repo_n, f.path)
+                resources[remote_map[f.path]] = _download_file(
+                    client, group, repo_n, f.path)
         else:
             paths = client.list_repo_files(group, repo_n)
             if not paths:
@@ -592,8 +639,8 @@ def cmd_download(
             total = len(paths)
             for i, pth in enumerate(paths, 1):
                 print(f'  [{i}/{total}] downloading {pth}', flush=True)
-                resources[remote_map[pth]] = client.download_repo_file(
-                    group, repo_n, pth)
+                resources[remote_map[pth]] = _download_file(
+                    client, group, repo_n, pth)
     except APIError as e:
         return _fail(api_error_message(e, 'download'))
     except Exception as e:
@@ -632,15 +679,31 @@ def cmd_download(
                 src_spec=src_spec,
                 dst_spec=spec,
                 collect_merges=download_merges,
+                # Same policy as cmd_convert: never invent target default
+                # templates the user did not have -- download+convert and
+                # local convert must produce identical file sets.
+                fill_missing_defaults=False,
             )
         else:
             existing_files = set(spec.collect().keys())
+            download_skips: list[str] = []
             resources = convert_resources(
                 resources,
                 framework,
                 target_fw,
                 existing_files=existing_files,
-                collect_merges=download_merges)
+                src_spec=build_spec(framework, local_name, local_dir),
+                dst_spec=spec,
+                collect_merges=download_merges,
+                collect_skips=download_skips,
+                fill_missing_defaults=False)
+            display.file_list(
+                'Skipped',
+                download_skips,
+                color=display.COLOR_SKIP,
+                marker='[skip]',
+                note='skill already exists on target, not overwritten',
+            )
 
     patterns = spec.resolved_patterns()
     filtered = {
@@ -787,6 +850,7 @@ def convert_workspace(
     if source_fw == target_fw:
         converted = resources
         default_paths: set = set()
+        skipped_skills: list = []
     elif src_spec._is_all() or dst_spec._is_all():
         # All-mode conversion only makes sense between two root-per-agent
         # frameworks (1:1 agent-directory mapping).  Other layouts (e.g.
@@ -810,11 +874,14 @@ def convert_workspace(
             collect_merges=merge_pairs,
         )
         default_paths = set()
+        skipped_skills = []
     else:
         # File-per-agent targets (e.g. qoder ``agents/{name}.md``) keep
         # per-agent identity in a dedicated sub-agent file; route overflow
         # (persona content with no shared mapping) there instead of the
         # shared catch-all so it does not pollute other sub-agents.
+        # Symmetrically, a file-per-agent SOURCE's persona file is flagged so
+        # it folds into the target's persona file instead of being dropped.
         overflow_target = None
         if any('{name}' in p for p in dst_spec.patterns):
             overflow_target = _file_per_agent_identity_path(dst_spec)
@@ -825,13 +892,18 @@ def convert_workspace(
             source_defaults=get_defaults(source_fw),
             target_defaults=get_defaults(target_fw),
             overflow_target=overflow_target,
+            identity_source=_file_per_agent_identity_path(src_spec),
             fill_missing_defaults=False,
+            existing_skills=_existing_skill_names(existing_paths),
         )
         default_paths = {
             a.path
             for a in result.actions if a.action == 'default'
         }
         merge_pairs = merged_away_pairs(result)
+        skipped_skills = sorted(
+            a.path for a in result.actions
+            if a.action == 'skip' and 'already exists' in a.detail)
         converted = result.merged_files
 
     dst_root = dst_spec.workspace_root
@@ -892,6 +964,13 @@ def convert_workspace(
         color=display.COLOR_DROPPED,
         marker='[drop]',
         note=f'not part of the {target_fw} workspace spec',
+    )
+    display.file_list(
+        'Skipped',
+        skipped_skills,
+        color=display.COLOR_SKIP,
+        marker='[skip]',
+        note='skill already exists on target, not overwritten',
     )
     if skipped_defaults:
         display.meta(
@@ -1107,9 +1186,20 @@ def _parse_backup_meta(stem: str) -> tuple[str, str]:
     Filenames look like ``{fw}{delim}{name}_{date}_{time}``; the leading
     ``{fw}{delim}{name}`` prefix is split on ``_`` (watch backups) or ``-``
     (upload backups).
+
+    The framework is anchored on REGISTERED framework names first (longest
+    match): ``ms-agent`` contains the ``-`` delimiter itself, so a naive
+    split would yield ``('ms', 'agent-default')`` and break ``backups -f
+    ms-agent`` filtering / restore lookup (BUG-032). Unregistered prefixes
+    keep the legacy split as a fallback.
     """
     parts = stem.rsplit('_', 2)
     prefix = parts[0] if len(parts) >= 3 else stem
+    for fw in sorted(FRAMEWORK_REGISTRY, key=len, reverse=True):
+        if prefix == fw:
+            return fw, ''  # all-scope backup: framework only
+        if prefix.startswith(fw + '_') or prefix.startswith(fw + '-'):
+            return fw, prefix[len(fw) + 1:]
     delim = '_' if '_' in prefix else '-'
     fw, _, nm = prefix.partition(delim)
     return fw, nm
@@ -1190,6 +1280,15 @@ def cmd_recover(
             f"unknown framework '{framework}'. Available: {available_frameworks()}"
         )
 
+    # Reject a corrupt / non-zip archive up front -- BEFORE the pre-restore
+    # backup and the delete-extra-files pass below touch the workspace, so a
+    # truncated or mislabeled backup fails cleanly (consistent _fail output,
+    # no half-done restore, no raw traceback).
+    if not zipfile.is_zipfile(zip_path):
+        return _fail(
+            f"restore failed: '{zip_path.name}' is not a valid backup "
+            f'archive (corrupt or not a zip file).')
+
     # Parse (framework, name) from the zip filename once, honoring both the
     # ``-`` (upload) and ``_`` (watch) delimiters, and fill in whatever the
     # caller left unspecified.  Reusing _parse_backup_meta keeps this aligned
@@ -1231,11 +1330,23 @@ def cmd_recover(
         print('No existing files to backup.')
 
     # Determine which files are in the zip (strip legacy wrapper prefix).
+    # Restore takes the SAME inbound rules as download: a zip can come from
+    # anywhere (--from-backup accepts arbitrary paths), so entries outside
+    # the workspace spec patterns (executable scripts, hidden credential
+    # files...) are rejected instead of written verbatim into the workspace.
+    spec_patterns = spec.resolved_patterns()
     with zipfile.ZipFile(zip_path, 'r') as zf:
-        zip_entries = {
+        all_entries = {
             _strip_backup_wrapper(info.filename)
             for info in zf.infolist() if not info.is_dir()
         }
+    zip_entries = {
+        rel
+        for rel in all_entries if spec.matches(rel, spec_patterns)
+    }
+    skipped_spec = sorted(all_entries - zip_entries)
+    for rel in skipped_spec:
+        print(f'  Skipped (not in {framework} workspace spec): {rel}')
 
     # Delete local files not in the zip
     deleted = 0
@@ -1256,12 +1367,17 @@ def cmd_recover(
             if info.is_dir():
                 continue
             rel = _strip_backup_wrapper(info.filename)
+            if rel not in zip_entries:
+                continue  # outside the workspace spec (already reported)
             file_target = (resolved_root / rel).resolve()
             if not file_target.is_relative_to(resolved_root):
                 print(f'  Skipped (path traversal): {info.filename}')
                 continue
             file_target.parent.mkdir(parents=True, exist_ok=True)
-            file_target.write_bytes(zf.read(info.filename))
+            # Same inbound sanitize download uses: a foreign zip's config may
+            # carry plaintext keys -- never write them to disk unscrubbed.
+            file_target.write_bytes(
+                spec.sanitize_inbound_file(rel, zf.read(info.filename)))
             print(f'  Restored: {rel}')
             restored += 1
 

--- a/ms_agent/agent_hub/_merge.py
+++ b/ms_agent/agent_hub/_merge.py
@@ -2,6 +2,7 @@
 """Section-level Markdown merge engine for cross-framework workspace migration."""
 from __future__ import annotations
 
+import difflib
 import re
 from dataclasses import dataclass, field
 
@@ -162,13 +163,21 @@ class SectionMerger:
         target_secs = self.parse_sections(target_default)
 
         actions = []
-        modified_titles = {sec.title for sec in modified}
-        modified_map = {sec.title: sec for sec in modified}
+        # Bucket modified sections BY TITLE INTO LISTS: a user file can
+        # legitimately contain several sections with the same heading, and a
+        # plain ``{title: sec}`` dict would keep only the last one, silently
+        # dropping the earlier bodies (BUG-025). When the target has that
+        # heading, ALL of the user's same-titled sections are placed there in
+        # their original order.
+        modified_by_title: dict[str, list[Section]] = {}
+        for sec in modified:
+            modified_by_title.setdefault(sec.title, []).append(sec)
 
         result_secs = []
         for tsec in target_secs:
-            if tsec.title in modified_titles:
-                result_secs.append(modified_map[tsec.title])
+            if tsec.title and modified_by_title.get(tsec.title):
+                user_secs = modified_by_title.pop(tsec.title)
+                result_secs.extend(user_secs)
                 actions.append(
                     MergeAction(
                         path='',
@@ -176,18 +185,15 @@ class SectionMerger:
                         detail=
                         f"Section '{tsec.title}' -- user modification preserved",
                     ))
-            elif not tsec.title and '' in modified_titles:
-                preamble_sec = modified_map.get('')
-                if preamble_sec:
-                    result_secs.append(preamble_sec)
-                    actions.append(
-                        MergeAction(
-                            path='',
-                            action='user_modified',
-                            detail='Preamble -- user modification preserved',
-                        ))
-                else:
-                    result_secs.append(tsec)
+            elif not tsec.title and modified_by_title.get(''):
+                preamble_sec = modified_by_title.pop('')[0]
+                result_secs.append(preamble_sec)
+                actions.append(
+                    MergeAction(
+                        path='',
+                        action='user_modified',
+                        detail='Preamble -- user modification preserved',
+                    ))
             else:
                 result_secs.append(tsec)
                 if tsec.title:
@@ -228,13 +234,30 @@ class HeartbeatMerger(SectionMerger):
     ACTIVE_TASKS_TITLE = '## Active Tasks'
 
     def _extract_task_lines(self, body: str) -> list[str]:
-        """Extract non-empty, non-comment lines from a section body."""
+        """Extract non-empty, non-comment lines from a section body.
+
+        Tracks multi-line ``<!-- ... -->`` comments: every line inside the
+        comment is skipped, not just the opener/closer -- otherwise the
+        middle lines of a user's block comment get treated as tasks and
+        inserted into the task area (BUG-029).
+        """
         lines = []
+        in_comment = False
         for line in body.split('\n'):
             stripped = line.strip()
-            if stripped and not stripped.startswith(
-                    '<!--') and not stripped.endswith('-->'):
-                lines.append(line)
+            if not stripped:
+                continue
+            if in_comment:
+                if '-->' in stripped:
+                    in_comment = False
+                continue
+            if stripped.startswith('<!--'):
+                if '-->' not in stripped:
+                    in_comment = True
+                continue
+            if stripped.endswith('-->'):
+                continue
+            lines.append(line)
         return lines
 
     def merge(
@@ -275,13 +298,23 @@ class HeartbeatMerger(SectionMerger):
         result_secs = self.parse_sections(result.content)
         for i, sec in enumerate(result_secs):
             if sec.title == self.ACTIVE_TASKS_TITLE:
+                # The base section merge may already have preserved the
+                # user's whole Active Tasks section (it counts as modified),
+                # in which case the new tasks are ALREADY in the result --
+                # appending them again would duplicate every task (BUG-028).
+                # Only insert the ones actually missing.
+                present = set(line.strip()
+                              for line in self._extract_task_lines(sec.body))
+                missing = [t for t in new_tasks if t.strip() not in present]
+                if not missing:
+                    return result
                 body_lines = sec.body.split('\n')
                 insert_idx = len(body_lines)
                 for j, line in enumerate(body_lines):
                     if '<!--' in line and j > 0:
                         insert_idx = j + 1
                         break
-                for task in new_tasks:
+                for task in missing:
                     body_lines.insert(insert_idx, task)
                     insert_idx += 1
                 result_secs[i] = Section(
@@ -289,6 +322,16 @@ class HeartbeatMerger(SectionMerger):
                     body='\n'.join(body_lines),
                 )
                 break
+        else:
+            # Target template has no ``## Active Tasks`` section at all --
+            # without a landing spot the user's tasks would be silently
+            # dropped (BUG-030). Create the section at the end so the tasks
+            # stay traceable in the merged file.
+            result_secs.append(
+                Section(
+                    title=self.ACTIVE_TASKS_TITLE,
+                    body='\n' + '\n'.join(new_tasks) + '\n',
+                ))
 
         result.content = self.sections_to_content(result_secs)
         result.actions.append(
@@ -553,18 +596,29 @@ def _resolve_target_path(source_product: str, source_path: str,
 
 
 def _extract_user_diff_text(user_content: str, source_default: str) -> str:
-    """Extract user customizations as a text block."""
+    """Extract user customizations as a text block.
+
+    Uses a positional line diff (not a global line-membership set): a user's
+    own paragraph may legitimately REUSE a line that also appears somewhere
+    in the template, and a set-based filter would delete it out of the middle
+    of the user's paragraph (BUG-026). The sequence diff only removes lines
+    where they positionally correspond to the template; the same text inside
+    a user-inserted block is kept intact.
+    """
     if not source_default.strip():
         return user_content.strip()
 
     user_lines = user_content.strip().split('\n')
     default_lines = source_default.strip().split('\n')
-    default_set = set(line.strip() for line in default_lines)
+    matcher = difflib.SequenceMatcher(
+        a=[line.strip() for line in default_lines],
+        b=[line.strip() for line in user_lines],
+        autojunk=False)
 
     diff_lines = []
-    for line in user_lines:
-        if line.strip() and line.strip() not in default_set:
-            diff_lines.append(line)
+    for tag, _i1, _i2, j1, j2 in matcher.get_opcodes():
+        if tag in ('insert', 'replace'):
+            diff_lines.extend(user_lines[j1:j2])
 
     return '\n'.join(diff_lines).strip()
 
@@ -594,6 +648,7 @@ def merge_resources(
     existing_skills: list[str] | None = None,
     fill_missing_defaults: bool = True,
     overflow_target: str | None = None,
+    identity_source: str | None = None,
 ) -> FullMergeResult:
     """Merge incoming resources into a target product workspace.
 
@@ -614,6 +669,13 @@ def merge_resources(
             targets (e.g. qoder ``agents/{name}.md``) so a converted persona
             lands in its own sub-agent file rather than polluting the shared
             ``AGENTS.md``.
+        identity_source: the SOURCE's per-agent persona file (file-per-agent
+            source, e.g. qoder ``agents/<name>.md``).  Its name embeds the
+            agent name so it can never appear in the static semantic path
+            map; without this hint the fallback would carry it over under its
+            original path and the target-spec filter would then drop it --
+            losing the persona.  Marking it here forces the overflow/catch-all
+            route (mirror of *overflow_target* for the outbound direction).
     """
     is_cross_product = source_product != target_product
     existing_skill_set = set(existing_skills or [])
@@ -629,9 +691,16 @@ def merge_resources(
     overflow_blocks: list[tuple[str, str]] = []
 
     for path, content in incoming.items():
-        # Skills: direct import, skip if exists
-        if path.startswith('skills/'):
-            parts = path.split('/')
+        # Skills: direct import, skip if exists.  Hermes' official
+        # ``optional-skills/`` tree is structurally identical to ``skills/``;
+        # cross-product it is normalized to ``skills/`` (no other framework
+        # has an optional-skills slot, so keeping the prefix would get the
+        # whole tree dropped by the target-spec filter downstream).
+        skill_path = path
+        if is_cross_product and path.startswith('optional-skills/'):
+            skill_path = 'skills/' + path[len('optional-skills/'):]
+        if skill_path.startswith('skills/'):
+            parts = skill_path.split('/')
             skill_name = parts[1] if len(parts) > 1 else ''
             if skill_name in existing_skill_set:
                 result.actions.append(
@@ -642,17 +711,25 @@ def merge_resources(
                         f"Skill '{skill_name}' already exists on target, skipped",
                     ))
                 continue
-            result.merged_files[path] = content
+            result.merged_files[skill_path] = content
             result.actions.append(
                 MergeAction(
-                    path=path,
+                    path=skill_path,
                     action='import',
-                    detail='Skill imported',
+                    detail='Skill imported' if skill_path == path else
+                    f'Optional skill imported (from {path})',
                 ))
             continue
 
-        target_path = _resolve_target_path(source_product, path,
-                                           target_product)
+        # The source's per-agent persona file (dynamic name, absent from the
+        # static path map): force the no-equivalent route so it folds into the
+        # target's persona file instead of being carried over verbatim and
+        # dropped by the target-spec filter downstream.
+        if is_cross_product and identity_source and path == identity_source:
+            target_path = None
+        else:
+            target_path = _resolve_target_path(source_product, path,
+                                               target_product)
 
         if target_path is None:
             if path.startswith('memory/') or path.startswith(

--- a/ms_agent/agent_hub/_sync.py
+++ b/ms_agent/agent_hub/_sync.py
@@ -56,10 +56,21 @@ def backup_local(spec, name: str) -> Path:
     """Zip all local agent files into a timestamped backup in the cache dir.
 
     Returns the path to the created zip file.
+
+    The timestamp is second-granular, so two backups within the same second
+    (e.g. convert + pre-restore in one scripted run) would collide and the
+    later write would OVERWRITE the earlier restore point (BUG-031). On
+    collision a ``-N`` suffix is appended INSIDE the time segment (never a
+    new ``_`` segment -- ``_parse_backup_meta`` relies on the stem's last
+    two ``_``-separated segments being date and time).
     """
     resources: dict[str, bytes] = spec.collect_bytes()
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
     zip_path = cache_dir() / f'{name}_{timestamp}.zip'
+    seq = 2
+    while zip_path.exists():
+        zip_path = cache_dir() / f'{name}_{timestamp}-{seq}.zip'
+        seq += 1
     zip_path.write_bytes(zip_resources(resources))
     return zip_path
 

--- a/ms_agent/agent_hub/_watcher.py
+++ b/ms_agent/agent_hub/_watcher.py
@@ -415,10 +415,15 @@ def daemonize(target, *args, **kwargs):
     pf.write_text(str(proc.pid), encoding='utf-8')
 
 
+# Process-discovery pattern for OUR daemon only.  ``daemonize`` starts the
+# daemon as ``<python> -m ms_agent.agent_hub._watcher _daemon <params.json>``,
+# so this exact argv marker uniquely identifies it.  Broad substrings like
+# ``'agent watch'`` must NEVER be used here: they match any unrelated process
+# whose command line happens to contain the text (a user's script, an editor
+# session...) and ``stop_daemon`` would SIGTERM it (BUG-014) -- while never
+# matching the real daemon, whose argv contains no such text.
 _DEFAULT_WATCH_PATTERNS = [
-    'agent watch',
-    'ms agent watch',
-    'modelscope agent watch',
+    'ms_agent.agent_hub._watcher _daemon',
 ]
 
 
@@ -438,9 +443,18 @@ def stop_daemon(extra_patterns: list[str] | None = None) -> bool:
     if pf.exists():
         try:
             tracked_pid = int(pf.read_text(encoding='utf-8').strip())
-            if hasattr(os, 'fork'):
-                os.kill(tracked_pid, signal.SIGTERM)
-            stopped = True
+            # A pid file can go stale (daemon died, OS reused the pid for an
+            # unrelated process) -- verify the process identity before
+            # signalling it.  If it is not our daemon, never signal it: the
+            # stop-file above is the primary mechanism anyway, so skipping
+            # the signal can at worst delay a real daemon's exit, while a
+            # wrong SIGTERM would kill a user's unrelated process.
+            if not _pid_is_watch_daemon(tracked_pid):
+                tracked_pid = None
+            else:
+                if hasattr(os, 'fork'):
+                    os.kill(tracked_pid, signal.SIGTERM)
+                stopped = True
         except (ValueError, OSError, ProcessLookupError):
             tracked_pid = None
 
@@ -471,6 +485,37 @@ def stop_daemon(extra_patterns: list[str] | None = None) -> bool:
     sf.unlink(missing_ok=True)
 
     return stopped or tracked_pid is not None
+
+
+def _pid_is_watch_daemon(pid: int) -> bool:
+    """Return True only if *pid*'s command line is OUR watch daemon.
+
+    Guards every signal sent to a pid-file pid: pids get recycled by the OS,
+    so an unverified kill could hit an unrelated user process. Any lookup
+    failure returns False (fail-safe: the stop-file still makes a real
+    daemon exit on its next poll).
+    """
+    marker = _DEFAULT_WATCH_PATTERNS[0]
+    try:
+        if hasattr(os, 'fork'):
+            result = subprocess.run(
+                ['ps', '-p', str(pid), '-o', 'command='],
+                capture_output=True,
+                text=True,
+                timeout=5)
+        else:
+            result = subprocess.run(
+                [
+                    'wmic', 'process', 'where', f'processid={int(pid)}', 'get',
+                    'commandline'
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        return result.returncode == 0 and marker in result.stdout
+    except (OSError, subprocess.TimeoutExpired, ValueError):
+        return False
 
 
 def _find_watch_pids(extra_patterns: list[str] | None = None) -> list[int]:

--- a/ms_agent/agent_hub/_workspace.py
+++ b/ms_agent/agent_hub/_workspace.py
@@ -51,9 +51,10 @@ GLOBAL_AGENT_NAME = '__global__'
 
 _SECRET_KEY_RE = re.compile(
     r'(?:^|[_-])'
-    r'(?:api[_-]?key|apikey|access[_-]?key|secret[_-]?key|client[_-]?secret|'
-    r'access[_-]?token|auth[_-]?token|token[_-]?file|'
-    r'key|token|secret|password|passwd|credentials?|sk)$',
+    r'(?:api[_-]?keys?|apikeys?|access[_-]?keys?|secret[_-]?keys?|'
+    r'client[_-]?secrets?|access[_-]?tokens?|auth[_-]?tokens?|token[_-]?file|'
+    r'authorization|bearer|cookies?|session[_-]?ids?|sessionids?|'
+    r'keys?|tokens?|secrets?|passwords?|passwd|credentials?|sk)$',
     re.IGNORECASE,
 )
 
@@ -84,10 +85,17 @@ def scrub_yaml_secrets(
       regardless of key name (that block is a free-form secret bag where API
       keys live under arbitrary names).
 
-    Lines that are not a simple ``key: <scalar>`` (comments, blank lines, list
-    items, mapping/block openers) are emitted verbatim. Flow-style mappings
-    (``env: {API_KEY: x}``) and block scalars are a known limitation of the
-    line-based approach and are left untouched.
+    Beyond simple ``key: <scalar>`` lines the scrubber also covers the other
+    legal spellings a secret can hide in:
+
+    * flow mappings (``llm: {api_key: X, model: y}``) -- secret pairs inside
+      the braces are cleared in place; an ``env: {...}`` flow mapping is
+      cleared wholesale;
+    * block/folded scalars (``api_key: |`` / ``>`` and their chomping
+      variants) -- the opener is blanked and the indented content lines that
+      carry the secret are dropped.
+
+    Comments, blank lines and non-secret lines are emitted verbatim.
 
     Shared by every framework whose config is YAML (hermes ``config.yaml``,
     ms-agent ``config.yaml`` / ``agent.yaml``) so they use one secret vocabulary.
@@ -95,13 +103,25 @@ def scrub_yaml_secrets(
     kv = re.compile(
         r'^(?P<indent>[ \t]*)(?P<key>[^\s:#][^:]*?)(?P<sep>[ \t]*:[ \t]*)'
         r'(?P<val>\S.*)?$')
+    flow_pair = re.compile(r'(?P<key>["\']?[\w.\-]+["\']?)(?P<sep>\s*:\s*)'
+                           r'(?P<val>[^,{}\[\]]+)')
+    block_opener = re.compile(r'^[|>][+-]?\d*$')
     # Indent of the active mcp-servers / nested ``env:`` block openers;
     # ``None`` means we are not currently inside that block.
     mcp_indent: int | None = None
     env_indent: int | None = None
+    # Inside a secret block scalar: drop lines indented deeper than this.
+    skip_indent: int | None = None
     out: list[str] = []
     for line in text.split('\n'):
         stripped = line.strip()
+        if skip_indent is not None:
+            if not stripped:
+                continue  # blank line inside the dropped block scalar
+            cur = len(line) - len(line.lstrip(' \t'))
+            if cur > skip_indent:
+                continue  # secret block-scalar content line: drop
+            skip_indent = None
         # Comments / blank lines never carry secrets nor change block scope.
         if not stripped or stripped.startswith('#'):
             out.append(line)
@@ -118,8 +138,35 @@ def scrub_yaml_secrets(
             mcp_indent = None
         key = m.group('key').strip()
         val = m.group('val')
-        has_scalar = val is not None and val.strip() not in ('|', '>', '{}',
-                                                             '[]')
+        in_env = env_indent is not None and indent > env_indent
+        secret_key = is_secret_key(key)
+        # Block/folded scalar opener (| / > + chomping variants): the secret
+        # lives on the FOLLOWING deeper-indented lines -- blank the key and
+        # drop that content.
+        if val is not None and block_opener.match(val.strip()):
+            if secret_key or in_env:
+                out.append(
+                    f"{m.group('indent')}{m.group('key')}{m.group('sep')}''")
+                skip_indent = indent
+            else:
+                out.append(line)
+            continue
+        # Flow mapping value: scrub secret pairs inside the braces. An
+        # ``env`` (or secret-named) flow mapping is a free-form secret bag ->
+        # clear every value in it.
+        if val is not None and val.lstrip().startswith(
+                '{') and val.strip() != '{}':
+            clear_all = secret_key or in_env or key == 'env'
+
+            def _repl(pm, _all=clear_all):
+                if _all or is_secret_key(pm.group('key').strip('"\'')):
+                    return f"{pm.group('key')}{pm.group('sep')}''"
+                return pm.group(0)
+
+            out.append(f"{m.group('indent')}{m.group('key')}{m.group('sep')}"
+                       f'{flow_pair.sub(_repl, val)}')
+            continue
+        has_scalar = val is not None and val.strip() not in ('{}', '[]')
         # A key with no scalar value opens a mapping/list block: track the
         # mcp-servers and nested ``env`` openers so their descendants can be
         # scoped, then emit the opener line unchanged.
@@ -130,8 +177,6 @@ def scrub_yaml_secrets(
                 env_indent = indent
             out.append(line)
             continue
-        secret_key = is_secret_key(key)
-        in_env = env_indent is not None and indent > env_indent
         if secret_key or in_env:
             out.append(
                 f"{m.group('indent')}{m.group('key')}{m.group('sep')}''")

--- a/ms_agent/agent_hub/frameworks/_bundled_skills.py
+++ b/ms_agent/agent_hub/frameworks/_bundled_skills.py
@@ -23,11 +23,14 @@ class BundledSkillFilterMixin:
 
     A ``skills/<dir>/`` is treated as framework-provided when its ``SKILL.md``
     frontmatter carries any of: a ``name`` listed in the sibling
-    ``.bundled_manifest`` (Hermes's content library); a top-level ``license``
-    field (the proprietary document skills); a ``builtin_skill_version`` field;
-    or a ``metadata`` block containing ``copaw`` / ``qwenpaw`` /
-    ``builtin_skill_version``. User skills carry none of these and are the only
-    ones kept. Only the ``skills/`` tree is filtered (Hermes's
+    ``.bundled_manifest`` (Hermes's content library); a ``builtin_skill_version``
+    field; or a ``metadata`` block whose nested product entry carries install
+    hints (``emoji``/``requires``/``install``). User skills carry none of these
+    and are the only ones kept. A bare ``license`` field or a bare
+    ``metadata.<product>`` key is deliberately NOT a marker: both appear on
+    user-authored skills (open-source license, custom per-product parameters)
+    and treating them as "bundled" silently dropped those skills
+    (BUG-021/BUG-022). Only the ``skills/`` tree is filtered (Hermes's
     ``optional-skills/`` is left untouched).
     """
 
@@ -70,6 +73,13 @@ class BundledSkillFilterMixin:
 
     def _is_framework_skill(self, skill_md: Path, bundled: frozenset) -> bool:
         """True when a ``SKILL.md`` is framework-provided (not user-authored)."""
+        # The manifest declaration is authoritative and must not depend on
+        # the frontmatter being parseable: a bundled skill whose YAML got
+        # corrupted would otherwise fail open into "user skill" and have its
+        # whole asset tree uploaded (BUG-023). The directory name IS the
+        # skill name in the manifest convention.
+        if skill_md.parent.name in bundled:
+            return True
         try:
             text = skill_md.read_text(encoding='utf-8')
         except OSError:
@@ -87,17 +97,18 @@ class BundledSkillFilterMixin:
         name = meta.get('name')
         if isinstance(name, str) and name.strip() in bundled:
             return True
-        if 'license' in meta or 'builtin_skill_version' in meta:
+        if 'builtin_skill_version' in meta:
             return True
         md = meta.get('metadata')
         if isinstance(md, dict):
-            # Bundled skills carry a metadata block that is either keyed by a
-            # product name (copaw/qwenpaw/openclaw) or holds a
-            # ``builtin_skill_version``; the nested product value carries
-            # install hints (``emoji``/``requires``/``install``). User skills
-            # have no such block.
-            if 'builtin_skill_version' in md or (
-                    md.keys() & {'copaw', 'qwenpaw', 'openclaw'}):
+            # Bundled skills carry a metadata block holding a
+            # ``builtin_skill_version``, or keyed by a product name
+            # (copaw/qwenpaw/openclaw) whose nested value carries install
+            # hints (``emoji``/``requires``/``install``). A product-name key
+            # ALONE is not enough (BUG-022): users legitimately store custom
+            # parameters under ``metadata.<product>``, so only the nested
+            # install-hint shape marks a skill as framework-provided.
+            if 'builtin_skill_version' in md:
                 return True
             for v in md.values():
                 if isinstance(v, dict) and (v.keys() & _BUNDLED_SKILL_KEYS):

--- a/ms_agent/agent_hub/frameworks/ms_agent.py
+++ b/ms_agent/agent_hub/frameworks/ms_agent.py
@@ -91,5 +91,32 @@ class MsAgentWorkspace(WorkspaceSpec):
                 data, ensure_ascii=False, indent=2).encode('utf-8')
         return content
 
+    def sanitize_outbound_file(self, rel_path: str, content: bytes) -> bytes:
+        """Fail-closed upload sanitize for the secret-bearing config files.
+
+        The inbound hook passes malformed content through verbatim (a broken
+        remote file adds no new exposure when written to disk), but on UPLOAD
+        that same pass-through would push the user's plaintext keys into the
+        remote repo's git history. So a config file we cannot parse -- and
+        therefore cannot verify as secret-free -- is refused here instead.
+        """
+        if rel_path == 'settings.json':
+            try:
+                json.loads(content)
+            except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+                raise ValueError(
+                    f'{rel_path} is not valid JSON; cannot verify it is free '
+                    f'of secrets -- refusing to upload it. Fix the file and '
+                    f'retry.')
+        elif rel_path in ('config.yaml', 'agent.yaml'):
+            try:
+                content.decode('utf-8')
+            except UnicodeDecodeError:
+                raise ValueError(
+                    f'{rel_path} is not valid UTF-8; cannot verify it is '
+                    f'free of secrets -- refusing to upload it. Fix the file '
+                    f'and retry.')
+        return self.sanitize_inbound_file(rel_path, content)
+
 
 register_framework('ms-agent', MsAgentWorkspace)

--- a/ms_agent/agent_hub/frameworks/openhuman.py
+++ b/ms_agent/agent_hub/frameworks/openhuman.py
@@ -72,15 +72,65 @@ class OpenhumanWorkspace(WorkspaceSpec):
     def _scrub_toml_secrets(self, text: str) -> str:
         # Allow dotted keys (``model.api_key = ...``) and test the last segment
         # so ``a.b.api_key`` is caught, not just a bare top-level ``api_key``.
+        # Beyond simple ``key = <scalar>`` lines this also covers:
+        # * inline tables  ``provider = { api_key = "X" }`` (incl. nested) --
+        #   secret pairs inside the braces are cleared in place;
+        # * arrays         ``tokens = ["X"]`` -> ``tokens = []``;
+        # * multi-line strings (``secret = '''`` / ``\"\"\"``) -- the opener is
+        #   blanked and the content lines up to the closing delimiter dropped.
         pattern = re.compile(
-            r'^(?P<pre>\s*(?P<key>[A-Za-z0-9_.-]+)\s*=\s*).*$')
+            r'^(?P<pre>\s*(?P<key>[A-Za-z0-9_.-]+)\s*=\s*)(?P<val>.*)$')
+        inline_pair = re.compile(r'(?P<key>[A-Za-z0-9_.-]+)(?P<sep>\s*=\s*)'
+                                 r'(?P<val>"[^"]*"|\'[^\']*\'|[^,{}\s][^,}]*)')
         out: list[str] = []
-        for line in text.split('\n'):
+        lines = text.split('\n')
+        i = 0
+        while i < len(lines):
+            line = lines[i]
             m = pattern.match(line)
-            if m and is_secret_key(m.group('key').split('.')[-1]):
-                out.append(m.group('pre') + '""')
-            else:
+            if not m:
                 out.append(line)
+                i += 1
+                continue
+            key = m.group('key').split('.')[-1]
+            val = m.group('val')
+            vstrip = val.strip()
+            if is_secret_key(key):
+                # Multi-line string: blank the opener and drop content lines
+                # up to (and including) the closing delimiter.
+                delim = next((d for d in ('"""', "'''")
+                              if vstrip.startswith(d) and vstrip.count(d) < 2),
+                             None)
+                if delim:
+                    out.append(m.group('pre') + '""')
+                    i += 1
+                    while i < len(lines) and delim not in lines[i]:
+                        i += 1
+                    i += 1  # skip the closing-delimiter line
+                    continue
+                if vstrip.startswith('['):
+                    out.append(m.group('pre') + '[]')
+                    if ']' not in vstrip:  # multi-line array
+                        i += 1
+                        while i < len(lines) and ']' not in lines[i]:
+                            i += 1
+                    i += 1
+                    continue
+                out.append(m.group('pre') + '""')
+                i += 1
+                continue
+            # Non-secret key: still scrub secret pairs inside inline tables
+            # (``provider = { api_key = "X" }``, nested tables included).
+            if '{' in vstrip:
+                out.append(
+                    m.group('pre') + inline_pair.sub(
+                        lambda pm: f"{pm.group('key')}{pm.group('sep')}\"\""
+                        if is_secret_key(pm.group('key').split('.')[-1]) else
+                        pm.group(0), val))
+                i += 1
+                continue
+            out.append(line)
+            i += 1
         return '\n'.join(out)
 
 

--- a/ms_agent/agent_hub/frameworks/qwenpaw.py
+++ b/ms_agent/agent_hub/frameworks/qwenpaw.py
@@ -135,9 +135,12 @@ class QwenpawWorkspace(BundledSkillFilterMixin, WorkspaceSpec):
 
         * channel configs additionally blank ``_CHANNEL_LOCAL_KEYS``
           (machine-local paths such as ``db_path``);
-        * every ``mcp.clients.*.env`` mapping is cleared wholesale -- env var
-          names are arbitrary, so values there are treated as secrets even
-          when the name does not match the vocabulary.
+        * every ``env`` mapping is cleared wholesale WHEREVER it lives -- env
+          var names are arbitrary, so values there are treated as secrets
+          even when the name does not match the vocabulary.  Anchoring on the
+          ``env`` key (not on a parent block name) keeps every MCP schema
+          spelling covered (``mcp.clients`` / ``mcp_clients`` /
+          ``mcpClients``), mirroring :func:`scrub_json_secrets`.
         """
 
         def scrub(node: Any) -> None:
@@ -148,6 +151,8 @@ class QwenpawWorkspace(BundledSkillFilterMixin, WorkspaceSpec):
                     # their inner field names happen to look harmless.
                     if is_secret_key(key):
                         node[key] = ''
+                    elif key == 'env' and isinstance(value, dict):
+                        node[key] = {k: '' for k in value}
                     elif isinstance(value, (dict, list)):
                         scrub(value)
             elif isinstance(node, list):
@@ -164,15 +169,6 @@ class QwenpawWorkspace(BundledSkillFilterMixin, WorkspaceSpec):
                 for key in list(ch.keys()):
                     if key in self._CHANNEL_LOCAL_KEYS:
                         ch[key] = ''
-        # MCP env blocks: clear every value regardless of the env var name.
-        mcp = data.get('mcp')
-        if isinstance(mcp, dict):
-            clients = mcp.get('clients')
-            if isinstance(clients, dict):
-                for client in clients.values():
-                    if isinstance(client, dict) and isinstance(
-                            client.get('env'), dict):
-                        client['env'] = {k: '' for k in client['env']}
 
     def _sanitize_agent_json(self, agent_name: str, content: str) -> str:
         """Rewrite machine-specific fields and strip per-channel secrets.
@@ -198,14 +194,22 @@ class QwenpawWorkspace(BundledSkillFilterMixin, WorkspaceSpec):
         """Strip secrets from an ``agent.json`` for upload (no identity rebind).
 
         Only the secret-bearing fields are blanked; ``id`` / ``workspace_dir``
-        keep their local values (they are rebound on the next download). On
-        parse failure the original text is returned unchanged.
+        keep their local values (they are rebound on the next download).
+
+        Sanitizing is a security boundary and the UPLOAD direction must fail
+        closed: a file we cannot parse cannot be verified secret-free, so a
+        malformed ``agent.json`` raises instead of being pushed verbatim
+        (which would put the user's plaintext keys into the remote repo's
+        git history forever).  The inbound (download) path keeps its
+        best-effort pass-through -- a malformed remote file adds no new
+        exposure when written to disk.
         """
         try:
             data: Any = json.loads(content)
         except (json.JSONDecodeError, ValueError):
-            logger.warning('agent.json is not valid JSON; writing as-is')
-            return content
+            raise ValueError(
+                'agent.json is not valid JSON; cannot verify it is free of '
+                'secrets -- refusing to upload it. Fix the file and retry.')
         if not isinstance(data, dict):
             return content
         self._strip_agent_json_secrets(data)
@@ -309,7 +313,9 @@ class QwenpawWorkspace(BundledSkillFilterMixin, WorkspaceSpec):
         try:
             text = content.decode('utf-8')
         except UnicodeDecodeError:
-            return content
+            raise ValueError(
+                f'{rel_path} is not valid UTF-8; cannot verify it is free of '
+                f'secrets -- refusing to upload it. Fix the file and retry.')
         return self._strip_outbound_agent_json(text).encode('utf-8')
 
     def apply(self, resources: dict[str, str]) -> list[str]:

--- a/tests/agent_hub/test_cli.py
+++ b/tests/agent_hub/test_cli.py
@@ -46,8 +46,13 @@ class _RepoStub:
             for p, c in self.STORE.items()
         ]
 
-    def download_repo_file(self, path, name, file_path):
-        return self.STORE[file_path]
+    def download_repo_file(self, path, name, file_path, revision="master",
+                           *, binary=False):
+        # Mirrors the real SDK: binary=True returns raw bytes, the default
+        # text mode decodes (and would corrupt non-UTF-8 binary content).
+        content = self.STORE[file_path]
+        raw = content if isinstance(content, bytes) else content.encode("utf-8")
+        return raw if binary else raw.decode("utf-8", errors="replace")
 
 
 # ---------------------------------------------------------------------------
@@ -698,6 +703,105 @@ class TestRestoreBehaviour(unittest.TestCase):
         self.assertEqual(fw, "qwenpaw")
         self.assertEqual(nm, "")
 
+    @mock.patch("pathlib.Path.home")
+    @mock.patch("ms_agent.agent_hub._sync.cache_dir")
+    @mock.patch("ms_agent.agent_hub._cache.cache_dir")
+    def test_restore_untrusted_zip_filtered_and_sanitized(self, mock_cache, mock_sync_cache, mock_home):
+        """Regression (BUG-013): restore must apply the same inbound rules as
+        download -- spec filtering (no foreign scripts / hidden credential
+        files written) plus inbound sanitize (no plaintext keys on disk)."""
+        mock_cache.return_value = self.cache_dir
+        mock_sync_cache.return_value = self.cache_dir
+        mock_home.return_value = self.home
+        agent_dir = self.ws / "bot-x"
+        agent_dir.mkdir()
+        self._make_backup(
+            "qwenpaw_bot-x_20260726_090000",
+            {
+                "SOUL.md": "# soul\nrestored.\n",
+                "agent.json": '{"id": "bot-x", "model": '
+                              '{"api_key": "SENTINEL-BUG013-KEY"}}',
+                "run_me.sh": "#!/bin/sh\necho pwned\n",
+                ".hidden_token": "SENTINEL-BUG013-SECRET\n",
+                "../escape.md": "outside\n",
+            },
+        )
+        rc = cmd_recover(target="qwenpaw_bot-x_20260726_090000",
+                         framework="qwenpaw", name="bot-x")
+        self.assertEqual(rc, 0)
+        written = {p.name for p in agent_dir.rglob("*") if p.is_file()}
+        # spec-listed files restored; foreign files rejected.
+        self.assertIn("SOUL.md", written)
+        self.assertNotIn("run_me.sh", written)
+        self.assertNotIn(".hidden_token", written)
+        self.assertNotIn("escape.md", written)
+        # inbound sanitize ran: the plaintext key never reached disk.
+        self.assertNotIn("SENTINEL-BUG013-KEY",
+                         (agent_dir / "agent.json").read_text())
+
+    def test_backup_meta_anchors_on_registered_framework_names(self):
+        """Regression (BUG-032): 'ms-agent' contains the '-' delimiter, so
+        parsing must anchor on registered framework names (longest first)
+        instead of splitting on the first delimiter."""
+        from ms_agent.agent_hub._commands import _parse_backup_meta
+        cases = {
+            "ms-agent-default_20260726_101010": ("ms-agent", "default"),
+            "ms-agent_20260726_101010": ("ms-agent", ""),
+            "ms-agent_default_20260726_101010": ("ms-agent", "default"),
+            "nanobot_default_20260726_101010": ("nanobot", "default"),
+            "qwenpaw_paw_qa_01_20260726_101010": ("qwenpaw", "paw_qa_01"),
+            "nanobot_default_20260731_133225-2": ("nanobot", "default"),
+            "unknownfw_myname_20260726_101010": ("unknownfw", "myname"),
+        }
+        for stem, expected in cases.items():
+            self.assertEqual(_parse_backup_meta(stem), expected, stem)
+
+    @mock.patch("ms_agent.agent_hub._sync.cache_dir")
+    def test_same_second_backups_do_not_overwrite(self, mock_sync_cache):
+        """Regression (BUG-031): two backups within the same second must get
+        distinct filenames (``-N`` inside the time segment), keeping every
+        restore point, and the suffix must not break filename parsing."""
+        import io
+        import zipfile as zf
+
+        from ms_agent.agent_hub._commands import _parse_backup_meta
+        from ms_agent.agent_hub._sync import backup_local
+        cache = Path(self.tmp.name) / "bk_cache"
+        cache.mkdir(exist_ok=True)
+        mock_sync_cache.return_value = cache
+        root = Path(self.tmp.name) / "bk_ws"
+        root.mkdir()
+        (root / "SOUL.md").write_text("V1\n")
+        spec = build_spec("nanobot", "default", str(root))
+        p1 = backup_local(spec, "nanobot_default")
+        (root / "SOUL.md").write_text("V2\n")
+        p2 = backup_local(spec, "nanobot_default")
+        self.assertNotEqual(p1, p2)
+        v1 = zf.ZipFile(io.BytesIO(p1.read_bytes())).read("SOUL.md").decode()
+        self.assertEqual(v1.strip(), "V1")  # first restore point intact
+        self.assertEqual(_parse_backup_meta(p2.stem), ("nanobot", "default"))
+
+    @mock.patch("pathlib.Path.home")
+    @mock.patch("ms_agent.agent_hub._sync.cache_dir")
+    @mock.patch("ms_agent.agent_hub._cache.cache_dir")
+    def test_restore_corrupt_zip_fails_cleanly(self, mock_cache, mock_sync_cache, mock_home):
+        """Regression (BUG-019): a corrupt / non-zip backup crashed with a
+        raw BadZipFile traceback. It must _fail with a readable message and
+        must not touch the workspace (no pre-restore backup, no deletes)."""
+        mock_cache.return_value = self.cache_dir
+        mock_sync_cache.return_value = self.cache_dir
+        mock_home.return_value = self.home
+        agent_dir = self.ws / "bot-x"
+        agent_dir.mkdir()
+        (agent_dir / "SOUL.md").write_text("# existing")
+        bad = self.cache_dir / "qwenpaw_bot-x_20260726_090000.zip"
+        bad.write_text("NOT-A-ZIP")
+        rc = cmd_recover(target=bad.name, framework="qwenpaw", name="bot-x")
+        self.assertEqual(rc, 1)
+        self.assertEqual((agent_dir / "SOUL.md").read_text(), "# existing")
+        # No pre-restore backup was produced before the rejection.
+        self.assertEqual(list(self.cache_dir.glob("*.zip")), [bad])
+
 
 # ---------------------------------------------------------------------------
 # Download command tests (stubbed client)
@@ -789,6 +893,112 @@ class TestDownload(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertTrue((self.out / "memories" / "USER.md").is_file())
         self.assertFalse((self.out / "USER.md").is_file())
+
+    @mock.patch("ms_agent.agent_hub._commands.AgentApi", _DownloadStub)
+    def test_download_binary_asset_byte_faithful(self):
+        """Regression (BUG-015): downloads went through text mode, so a
+        binary asset's non-UTF-8 bytes (PNG magic ``\\x89``) got mangled by
+        decode/re-encode. Downloads must be byte-faithful."""
+        png = b"\x89PNG\r\n\x1a\nopenhuman"
+        orig_store = _DownloadStub.STORE.copy()
+        _DownloadStub.STORE = {
+            "SOUL.md": "soul",
+            "skills/draw/assets/pic.png": png,
+        }
+        try:
+            rc = cmd_download(
+                framework="nanobot", repo="nano",
+                local_dir=str(self.out),
+                endpoint="http://s", token="tok", username="u",
+            )
+            self.assertEqual(rc, 0)
+            written = (self.out / "skills" / "draw" / "assets"
+                       / "pic.png").read_bytes()
+            self.assertEqual(written, png)
+            # Text files still round-trip as text.
+            self.assertEqual((self.out / "SOUL.md").read_text(), "soul")
+        finally:
+            _DownloadStub.STORE = orig_store
+
+    @mock.patch("ms_agent.agent_hub._sync.cache_dir")
+    @mock.patch("ms_agent.agent_hub._commands.AgentApi", _DownloadStub)
+    def test_existing_skill_not_overwritten(self, mock_sync_cache):
+        """Regression (BUG-024): cross-framework convert/download must skip a
+        skill the target already has instead of silently overwriting it."""
+        from ms_agent.agent_hub._commands import cmd_convert
+        cache = Path(self.tmp.name) / "cache"
+        cache.mkdir(exist_ok=True)
+        mock_sync_cache.return_value = cache
+        # convert path: target dst already has skills/demo with own content.
+        src = Path(self.tmp.name) / "cv_src"
+        (src / "skills" / "demo").mkdir(parents=True)
+        (src / "SOUL.md").write_text("# soul")
+        (src / "skills" / "demo" / "SKILL.md").write_text("SRC VERSION")
+        dst = Path(self.tmp.name) / "cv_dst"
+        (dst / "skills" / "demo").mkdir(parents=True)
+        (dst / "skills" / "demo" / "SKILL.md").write_text("TARGET VERSION")
+        rc = cmd_convert("hermes", "nanobot", from_name="default",
+                         local_dir=str(src), out_dir=str(dst))
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            (dst / "skills" / "demo" / "SKILL.md").read_text(),
+            "TARGET VERSION")
+        # download path: local workspace already has skills/demo.
+        dl = Path(self.tmp.name) / "dl_ws"
+        (dl / "skills" / "demo").mkdir(parents=True)
+        (dl / "skills" / "demo" / "SKILL.md").write_text("LOCAL VERSION")
+        orig_store = _DownloadStub.STORE.copy()
+        _DownloadStub.STORE = {
+            "SOUL.md": "soul",
+            "skills/demo/SKILL.md": "REMOTE VERSION",
+        }
+        try:
+            rc = cmd_download(
+                framework="hermes", repo="h", target="nanobot",
+                local_dir=str(dl),
+                endpoint="http://s", token="tok", username="u")
+        finally:
+            _DownloadStub.STORE = orig_store
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            (dl / "skills" / "demo" / "SKILL.md").read_text(),
+            "LOCAL VERSION")
+
+    @mock.patch("ms_agent.agent_hub._commands.AgentApi", _DownloadStub)
+    def test_download_convert_parity_with_local_convert(self):
+        """Regression (BUG-020): ``download --target-framework`` must produce
+        the SAME file set as a local ``convert`` -- same persona routing for
+        file-per-agent targets (agents/<name>.md, no shared AGENTS.md
+        pollution) and no invented target default templates."""
+        from ms_agent.agent_hub._commands import cmd_convert
+        src = Path(self.tmp.name) / "src"
+        src.mkdir()
+        for rel, content in _DownloadStub.STORE.items():
+            p = src / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content)
+        for target, kwargs in (("qoder", {"name": "myagent"}),
+                               ("hermes", {})):
+            dl = Path(self.tmp.name) / f"dl_{target}"
+            cv = Path(self.tmp.name) / f"cv_{target}"
+            rc = cmd_download(
+                framework="nanobot", repo="nano", target=target,
+                local_dir=str(dl),
+                endpoint="http://s", token="tok", username="u", **kwargs)
+            self.assertEqual(rc, 0)
+            rc = cmd_convert(
+                "nanobot", target, from_name="default",
+                target_name=kwargs.get("name"),
+                local_dir=str(src), out_dir=str(cv))
+            self.assertEqual(rc, 0)
+            dl_files = sorted(
+                str(p.relative_to(dl)) for p in dl.rglob("*") if p.is_file())
+            cv_files = sorted(
+                str(p.relative_to(cv)) for p in cv.rglob("*") if p.is_file())
+            self.assertEqual(dl_files, cv_files, f"target={target}")
+        # file-per-agent target: persona landed in its private file.
+        self.assertTrue((Path(self.tmp.name) / "dl_qoder" / "agents"
+                         / "myagent.md").is_file())
 
     def test_download_without_login_fails(self):
         rc = cmd_download(
@@ -1024,6 +1234,33 @@ class TestConvert(unittest.TestCase):
             local_dir=str(self.src / "missing"),
         )
         self.assertEqual(rc, 1)
+
+    @mock.patch("ms_agent.agent_hub._sync.cache_dir")
+    def test_convert_twice_is_idempotent(self, mock_sync_cache):
+        """Regression (BUG-027): re-running convert into the same out-dir
+        must neither duplicate the '## Imported from' overflow block nor
+        wipe the previously migrated user content down to zero."""
+        from ms_agent.agent_hub._defaults import get_defaults
+        cache = Path(self.tmp.name) / "cache"
+        cache.mkdir(exist_ok=True)
+        mock_sync_cache.return_value = cache
+        root = Path(self.tmp.name) / "qp"
+        ws = root / "workspaces" / "default"
+        ws.mkdir(parents=True)
+        (ws / "PROFILE.md").write_text(
+            get_defaults("qwenpaw")["PROFILE.md"]
+            + "\n\n## My Marker\n\nMRGMARKER\n")
+        (ws / "SOUL.md").write_text("# soul\nCUSTOM SOUL\n")
+        out = Path(self.tmp.name) / "oc"
+        for _ in range(2):
+            rc = cmd_convert(
+                source_fw="qwenpaw", target_fw="openclaw",
+                from_name="default",
+                local_dir=str(root), out_dir=str(out))
+            self.assertEqual(rc, 0)
+        agents = (out / "workspace" / "AGENTS.md").read_text()
+        self.assertEqual(agents.count("## Imported from"), 1)
+        self.assertEqual(agents.count("MRGMARKER"), 1)
 
 
 class TestFrameworkUploadCoverage(unittest.TestCase):

--- a/tests/agent_hub/test_convert_targetname.py
+++ b/tests/agent_hub/test_convert_targetname.py
@@ -304,8 +304,12 @@ class _StoreStub:
             for p, c in self.STORE.items()
         ]
 
-    def download_repo_file(self, path, name, file_path):
-        return self.STORE[file_path]
+    def download_repo_file(self, path, name, file_path, revision="master",
+                           *, binary=False):
+        content = self.STORE[file_path]
+        raw = (content if isinstance(content, bytes) else
+               content.encode("utf-8"))
+        return raw if binary else raw.decode("utf-8", errors="replace")
 
 
 class _QwenpawAllStore(_StoreStub):
@@ -552,6 +556,137 @@ class TestFourFrameworkConvertMatrix(unittest.TestCase):
         self.assertIn("OC_MEM_MARKER", files["MEMORY.md"])
         # single-agent target: no agent-prefixed dirs.
         self.assertFalse(any("bot-a" in p for p in files))
+
+
+class TestQoderPersonaOutbound(unittest.TestCase):
+    """Converting OUT of qoder must not lose the per-agent persona file.
+
+    Regression: ``agents/<name>.md`` (the persona body of a file-per-agent
+    qoder sub-agent) is absent from the static semantic path map, so the
+    resolver carried it over under its original path and the target-spec
+    filter then dropped it -- persona lost on every qoder->X conversion
+    while X->qoder had a working fold-in. Now the source persona file is
+    flagged (identity_source) and folds into the target's persona/catch-all
+    file, surfaced as Merged.
+    """
+
+    PERSONA = "# persona\n\u540d\u5b57\uff1a\u6d4b\u8bd5\u67b6\u6784\u5e08\nGOLD-QODER-PERSONA\n"
+    SHARED = "# AGENTS.md\n## Shared Rules\n- GOLD-QODER-SHARED\n"
+
+    def _convert(self, target_fw: str):
+        """Run a real cmd_convert from an on-disk qoder workspace; return
+        {rel_path: content} of everything written under out_dir."""
+        with tempfile.TemporaryDirectory() as td:
+            src = Path(td) / "src"
+            (src / "agents").mkdir(parents=True)
+            (src / "AGENTS.md").write_text(self.SHARED)
+            (src / "agents" / "test-architect.md").write_text(self.PERSONA)
+            out = Path(td) / "out"
+            rc = cmd_convert(
+                "qoder", target_fw,
+                from_name="test-architect", target_name="default",
+                local_dir=str(src), out_dir=str(out))
+            self.assertEqual(rc, 0)
+            return {
+                str(p.relative_to(out)): p.read_text()
+                for p in out.rglob("*") if p.is_file()
+            }
+
+    def test_persona_survives_to_every_target(self):
+        """RISK-001: all 6 outbound targets keep the persona body."""
+        expected_home = {
+            "hermes": "SOUL.md",
+            "openclaw": "workspace/AGENTS.md",
+            "qwenpaw": "workspaces/default/AGENTS.md",
+            "nanobot": "AGENTS.md",
+            "openhuman": "SOUL.md",
+            "ms-agent": "profile.md",
+        }
+        for target, home in expected_home.items():
+            files = self._convert(target)
+            holders = [p for p, c in files.items() if "GOLD-QODER-PERSONA" in c]
+            self.assertEqual(
+                holders, [home],
+                f"qoder->{target}: persona expected in {home}, got {holders}")
+            # shared AGENTS.md rules still migrate too.
+            self.assertTrue(
+                any("GOLD-QODER-SHARED" in c for c in files.values()),
+                f"qoder->{target}: shared rules lost")
+
+    def test_reverse_direction_not_regressed(self):
+        """hermes -> qoder still folds SOUL.md into agents/<target-name>.md."""
+        with tempfile.TemporaryDirectory() as td:
+            src = Path(td) / "src"
+            src.mkdir()
+            (src / "SOUL.md").write_text("# Soul\nGOLD-HERMES-PERSONA\n")
+            out = Path(td) / "out"
+            rc = cmd_convert(
+                "hermes", "qoder",
+                from_name="default", target_name="test-architect",
+                local_dir=str(src), out_dir=str(out))
+            self.assertEqual(rc, 0)
+            persona = out / "agents" / "test-architect.md"
+            self.assertTrue(persona.is_file())
+            self.assertIn("GOLD-HERMES-PERSONA", persona.read_text())
+
+
+class TestHermesOptionalSkillsOutbound(unittest.TestCase):
+    """hermes ``optional-skills/`` must survive cross-framework conversion.
+
+    Regression (RISK-004): only the ``skills/`` prefix took the skill-import
+    route in merge_resources; ``optional-skills/`` fell through to the
+    generic branch, was carried over under its original path and then
+    dropped by the target-spec filter -- the whole optional skill tree
+    silently vanished on every hermes->X conversion while ``skills/``
+    migrated fine. Now it is normalized to ``skills/<name>/**`` cross-product.
+    """
+
+    def _make_src(self, td):
+        src = Path(td) / "src"
+        (src / "skills" / "daily-report").mkdir(parents=True)
+        (src / "optional-skills" / "git-helper").mkdir(parents=True)
+        (src / "SOUL.md").write_text("# Soul\npersona\n")
+        (src / "skills" / "daily-report" / "SKILL.md").write_text(
+            "GOLD-SKILL\n")
+        (src / "optional-skills" / "git-helper" / "SKILL.md").write_text(
+            "GOLD-HERMES-DEFAULT-OPTSKILL\n")
+        return src
+
+    def test_optional_skill_normalized_to_skills_on_every_target(self):
+        for target in ("openclaw", "qwenpaw", "nanobot", "openhuman",
+                       "qoder", "ms-agent"):
+            with tempfile.TemporaryDirectory() as td:
+                src = self._make_src(td)
+                out = Path(td) / "out"
+                rc = cmd_convert(
+                    "hermes", target,
+                    from_name="default", target_name="default",
+                    local_dir=str(src), out_dir=str(out))
+                self.assertEqual(rc, 0)
+                hits = [
+                    str(p.relative_to(out)) for p in out.rglob("*")
+                    if p.is_file() and "OPTSKILL" in p.read_text()
+                ]
+                # normalized under skills/<name>/, wherever the workspace root is.
+                self.assertEqual(
+                    len(hits), 1,
+                    f"hermes->{target}: optional skill lost or duplicated: {hits}")
+                self.assertIn("skills/git-helper/SKILL.md", hits[0])
+                self.assertNotIn("optional-skills", hits[0])
+
+    def test_same_framework_keeps_original_prefix(self):
+        """hermes -> hermes stays byte-faithful: optional-skills/ untouched."""
+        with tempfile.TemporaryDirectory() as td:
+            src = self._make_src(td)
+            out = Path(td) / "out"
+            rc = cmd_convert(
+                "hermes", "hermes",
+                from_name="default", target_name="default",
+                local_dir=str(src), out_dir=str(out))
+            self.assertEqual(rc, 0)
+            kept = out / "optional-skills" / "git-helper" / "SKILL.md"
+            self.assertTrue(kept.is_file())
+            self.assertIn("OPTSKILL", kept.read_text())
 
 
 if __name__ == "__main__":

--- a/tests/agent_hub/test_merge.py
+++ b/tests/agent_hub/test_merge.py
@@ -89,6 +89,80 @@ class TestSectionMergerMerge(unittest.TestCase):
         result = self.merger.merge(user, source_default, target_default)
         self.assertIn("user modified", result.content)
 
+    def test_merge_keeps_all_duplicate_titled_sections(self):
+        """Regression (BUG-025): two user sections sharing one heading must
+        BOTH survive the merge, in their original order (the old
+        ``{title: sec}`` map silently kept only the last one)."""
+        result = self.merger.merge(
+            "## Rules\n\nMARK-A\n\n## Rules\n\nMARK-B\n",
+            "## Rules\n\ndefault rules\n",
+            "## Rules\n\ntarget rules\n",
+        )
+        self.assertIn("MARK-A", result.content)
+        self.assertIn("MARK-B", result.content)
+        self.assertLess(
+            result.content.find("MARK-A"), result.content.find("MARK-B"))
+        # The target default body they replaced is gone, not duplicated.
+        self.assertNotIn("target rules", result.content)
+
+    def test_user_diff_keeps_template_line_reused_in_user_paragraph(self):
+        """Regression (BUG-026): a line the user REUSES inside their own new
+        paragraph must survive extraction -- the old global line-set filter
+        deleted it out of the middle of the paragraph. A pristine template
+        still extracts to empty."""
+        from ms_agent.agent_hub._merge import _extract_user_diff_text
+        template = "# T\n\n- keep this line\n- another line\n"
+        user = template + "\n## My List\n\nHEAD\n- keep this line\nTAIL\n"
+        out = _extract_user_diff_text(user, template)
+        self.assertIn("HEAD", out)
+        self.assertIn("- keep this line", out)
+        self.assertIn("TAIL", out)
+        self.assertNotIn("- another line", out)
+        self.assertEqual(_extract_user_diff_text(template, template), "")
+
+    def test_heartbeat_new_tasks_appear_exactly_once(self):
+        """Regression (BUG-028): the base section merge already keeps the
+        user's Active Tasks section; the task-level pass must only fill in
+        MISSING tasks, not append every new task a second time."""
+        from ms_agent.agent_hub._defaults import get_defaults
+        from ms_agent.agent_hub._merge import merge_resources
+        src = get_defaults("qwenpaw")["HEARTBEAT.md"]
+        user = src.replace(
+            "## Active Tasks",
+            "## Active Tasks\n\n- [ ] MARK-TASK-NEW\n- [x] MARK-TASK-DONE")
+        r = merge_resources({"HEARTBEAT.md": user}, "qwenpaw", "nanobot",
+                            source_defaults=get_defaults("qwenpaw"),
+                            target_defaults=get_defaults("nanobot"))
+        txt = r.merged_files.get("HEARTBEAT.md", "")
+        self.assertEqual(txt.count("MARK-TASK-NEW"), 1)
+        # checkbox states preserved verbatim.
+        self.assertIn("- [ ] MARK-TASK-NEW", txt)
+        self.assertIn("- [x] MARK-TASK-DONE", txt)
+
+    def test_heartbeat_multiline_comment_lines_are_not_tasks(self):
+        """Regression (BUG-029): lines INSIDE a multi-line <!-- ... -->
+        comment must not be extracted as tasks (only the opener/closer used
+        to be excluded)."""
+        from ms_agent.agent_hub._merge import HeartbeatMerger
+        m = HeartbeatMerger()
+        tasks = m._extract_task_lines(
+            "<!--\ncomment A\ncomment B\n-->\n"
+            "- [ ] REAL\n<!-- single -->\nplain")
+        self.assertEqual(tasks, ["- [ ] REAL", "plain"])
+
+    def test_heartbeat_target_without_active_tasks_keeps_user_tasks(self):
+        """Regression (BUG-030): when the target template lacks an
+        '## Active Tasks' section, the user's tasks must land in a newly
+        created section instead of being silently dropped."""
+        from ms_agent.agent_hub._merge import HeartbeatMerger
+        r = HeartbeatMerger().merge(
+            "## Active Tasks\n\n- [ ] MARK-ORPHAN-TASK\n",
+            "## Active Tasks\n\n<!-- add -->\n",
+            "# Heartbeat\n\nno active tasks section here\n")
+        self.assertIn("- [ ] MARK-ORPHAN-TASK", r.content)
+        self.assertIn("## Active Tasks", r.content)
+        self.assertIn("no active tasks section here", r.content)
+
     def test_merge_appends_user_added_sections(self):
         user = "## Section A\nbody A\n## Custom Section\ncustom content"
         source_default = "## Section A\nbody A"

--- a/tests/agent_hub/test_watch_sync.py
+++ b/tests/agent_hub/test_watch_sync.py
@@ -25,6 +25,7 @@ import multiprocessing
 import os
 import shutil
 import signal
+import subprocess
 import sys
 import tempfile
 import time
@@ -328,7 +329,12 @@ class TestWatchSync(unittest.TestCase):
             proc = self._start_watch("qwenpaw", ALL_AGENT_NAME, local_dir, repo_name, push_only=False)
             self._wait_cycles(2)
 
-            remote = self.client.list_repo_files(self.username, repo_name)
+            # Poll instead of a single bare read: a freshly created repo may
+            # 404 for a few seconds on the server side (eventual consistency).
+            remote = self._eventually(
+                lambda: (lambda fl: fl if "bot-a/SOUL.md" in fl and "bot-b/SOUL.md" in fl else None)(
+                    self.client.list_repo_files(self.username, repo_name)),
+                desc="initial push visible on remote")
             self.assertIn("bot-a/SOUL.md", remote)
             self.assertIn("bot-b/SOUL.md", remote)
 
@@ -869,6 +875,74 @@ class TestWatchSync(unittest.TestCase):
             if proc:
                 self._stop_watch(proc)
             self._cleanup(local_dir)
+
+
+class TestStopDaemonTargeting(unittest.TestCase):
+    """``agent stop`` must only ever signal OUR watch daemon (BUG-014).
+
+    Offline: uses throwaway ``sleep`` child processes with crafted argv and
+    a temp-dir pid/stop file, no network or real daemon involved.
+    """
+
+    def _stop(self, tmp, pid_content=None):
+        from unittest import mock
+
+        from ms_agent.agent_hub import _watcher
+        tmp = Path(tmp)
+        if pid_content is not None:
+            (tmp / "watch.pid").write_text(str(pid_content))
+        with mock.patch.object(_watcher, "pid_file",
+                               return_value=tmp / "watch.pid"), \
+                mock.patch.object(_watcher, "stop_file",
+                                  return_value=tmp / "watch.stop"):
+            return _watcher.stop_daemon()
+
+    def test_unrelated_process_with_watch_text_survives(self):
+        """Regression: argv merely CONTAINING 'agent watch' used to get
+        SIGTERMed by the pgrep sweep."""
+        proc = subprocess.Popen([
+            sys.executable, "-c", "import time; time.sleep(60)", "ms-agent",
+            "agent", "watch", "-f", "nanobot"
+        ])
+        try:
+            time.sleep(0.5)
+            with tempfile.TemporaryDirectory() as td:
+                rc = self._stop(td)
+            time.sleep(0.5)
+            self.assertFalse(rc)  # cmd_stop prints 'No watch process running'
+            self.assertIsNone(proc.poll(), "unrelated process was killed")
+        finally:
+            proc.kill()
+
+    def test_real_daemon_marker_is_found_and_stopped(self):
+        """A process carrying the daemon's exact argv marker IS stopped."""
+        proc = subprocess.Popen([
+            sys.executable, "-c", "import time; time.sleep(60)",
+            "ms_agent.agent_hub._watcher", "_daemon", "/tmp/x.json"
+        ])
+        try:
+            time.sleep(0.5)
+            with tempfile.TemporaryDirectory() as td:
+                rc = self._stop(td)
+            time.sleep(1)
+            self.assertTrue(rc)
+            self.assertIsNotNone(proc.poll(), "daemon-marked process survived")
+        finally:
+            proc.kill()
+
+    def test_stale_pid_file_pointing_at_foreign_process(self):
+        """A recycled pid in the pid file must not be signalled."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"])
+        try:
+            time.sleep(0.5)
+            with tempfile.TemporaryDirectory() as td:
+                rc = self._stop(td, pid_content=proc.pid)
+            time.sleep(0.5)
+            self.assertFalse(rc)
+            self.assertIsNone(proc.poll(), "foreign pid-file pid was killed")
+        finally:
+            proc.kill()
 
 
 if __name__ == "__main__":

--- a/tests/agent_hub/test_workspace.py
+++ b/tests/agent_hub/test_workspace.py
@@ -39,19 +39,43 @@ class TestAgentAwareCollect(unittest.TestCase):
 
     def test_hermes_excludes_framework_skills_keeps_user_skills(self):
         """hermes collect drops bundled/framework skills (identified by a
-        license / builtin_skill_version / metadata.copaw frontmatter marker) but
-        keeps the user's own skills (which have no such markers)."""
+        builtin_skill_version / metadata.copaw frontmatter marker or a
+        .bundled_manifest entry) but keeps the user's own skills -- including
+        open-source ones whose frontmatter carries a ``license`` field
+        (BUG-021: license alone must NOT mark a skill as bundled)."""
         spec = build_spec("hermes", "default", str(self.root))
         base = spec.workspace_root
         (base / "skills" / "docx").mkdir(parents=True, exist_ok=True)
         (base / "skills" / "docx" / "SKILL.md").write_text(
-            "---\nname: docx\nlicense: MIT\n---\n# docx\nbuiltin\n", encoding="utf-8")
+            "---\nname: docx\nlicense: MIT\nbuiltin_skill_version: '1.0'\n"
+            "---\n# docx\nbuiltin\n", encoding="utf-8")
         (base / "skills" / "write").mkdir(parents=True, exist_ok=True)
         (base / "skills" / "write" / "SKILL.md").write_text(
             "# Write\nUser's own writing skill.\n", encoding="utf-8")
+        (base / "skills" / "my-open-skill").mkdir(parents=True, exist_ok=True)
+        (base / "skills" / "my-open-skill" / "SKILL.md").write_text(
+            "---\nname: my-open-skill\ndescription: x\nlicense: Apache-2.0\n"
+            "---\n\nBODY\n", encoding="utf-8")
+        # BUG-022: a bare metadata.<product> key holding CUSTOM parameters
+        # (no install hints) is a user skill, not a bundled one.
+        (base / "skills" / "my-meta-skill").mkdir(parents=True, exist_ok=True)
+        (base / "skills" / "my-meta-skill" / "SKILL.md").write_text(
+            "---\nname: my-meta-skill\nmetadata:\n  openclaw:\n"
+            "    my_param: 1\n---\n\nBODY\n", encoding="utf-8")
+        # BUG-023: a manifest-declared bundled skill stays bundled even when
+        # its frontmatter YAML is corrupt (fail-closed, never uploaded).
+        (base / "skills" / ".bundled_manifest").write_text(
+            "broken-bundled:deadbeef\n", encoding="utf-8")
+        (base / "skills" / "broken-bundled").mkdir(parents=True, exist_ok=True)
+        (base / "skills" / "broken-bundled" / "SKILL.md").write_text(
+            "---\nname: broken-bundled\n: : bad yaml : :\n---\nBODY\n",
+            encoding="utf-8")
         collected = spec.collect()
         self.assertIn("skills/write/SKILL.md", collected)
+        self.assertIn("skills/my-open-skill/SKILL.md", collected)
+        self.assertIn("skills/my-meta-skill/SKILL.md", collected)
         self.assertNotIn("skills/docx/SKILL.md", collected)
+        self.assertNotIn("skills/broken-bundled/SKILL.md", collected)
 
     def test_hermes_collects_hooks_same_framework(self):
         """hermes collects ``hooks/*`` (lifecycle hooks) for same-framework
@@ -84,14 +108,16 @@ class TestAgentAwareCollect(unittest.TestCase):
 
     def test_qwenpaw_excludes_framework_skills_keeps_user_skills(self):
         """qwenpaw (CoPaw) shares BundledSkillFilterMixin: framework skills
-        (license / metadata.copaw|qwenpaw markers, no .bundled_manifest) are
-        dropped with all their assets; user skills are kept."""
+        (builtin_skill_version / metadata.copaw|qwenpaw markers, no
+        .bundled_manifest) are dropped with all their assets; user skills are
+        kept."""
         spec = build_spec("qwenpaw", "default", str(self.root))
         base = spec.workspace_root
         docx = base / "skills" / "docx" / "scripts"
         docx.mkdir(parents=True, exist_ok=True)
         (base / "skills" / "docx" / "SKILL.md").write_text(
-            "---\nname: docx\nlicense: Proprietary\n---\n# docx\n", encoding="utf-8")
+            "---\nname: docx\nlicense: Proprietary\n"
+            "builtin_skill_version: '1.0'\n---\n# docx\n", encoding="utf-8")
         (docx / "helper.py").write_text("# bundled asset\n", encoding="utf-8")
         cron = base / "skills" / "cron"
         cron.mkdir(parents=True, exist_ok=True)
@@ -304,6 +330,137 @@ class TestQwenpawAgentJsonSecrets(unittest.TestCase):
         out = json.loads(self.spec._sanitize_agent_json("paw_qa_01", self.SRC))
         self._assert_scrubbed(out)
         self.assertNotIn("SECRET", json.dumps(out))
+
+    def test_env_cleared_for_every_mcp_schema_spelling(self):
+        """Regression (BUG-011): the wholesale env-clear rule was anchored on
+        the ``mcp.clients`` path only; ``mcp_clients`` / ``mcpClients``
+        spellings leaked non-vocabulary env values in plaintext."""
+        sentinel = "SENTINEL-BUG011-CUSTOM"
+        for name, payload in {
+                "mcp.clients": {"mcp": {"clients": {"fetch": {"env": {"CUSTOM_VALUE": sentinel}}}}},
+                "mcp_clients": {"mcp_clients": {"fetch": {"env": {"CUSTOM_VALUE": sentinel}}}},
+                "mcpClients": {"mcpClients": {"fetch": {"env": {"CUSTOM_VALUE": sentinel}}}},
+        }.items():
+            body = json.dumps({"id": "bot-a", **payload})
+            out = self.spec._strip_outbound_agent_json(body)
+            self.assertNotIn(sentinel, out, f"MCP schema '{name}' leaked env value")
+            # env keys preserved (values blanked), structure intact.
+            self.assertIn("CUSTOM_VALUE", out)
+
+
+class TestScrubYamlTomlSpellings(unittest.TestCase):
+    """YAML/TOML scrubbers must catch every legal spelling of a secret.
+
+    Regression (BUG-010): the line-based scrubbers only handled simple
+    ``key: <scalar>`` / ``key = <scalar>`` lines; flow mappings, block/folded
+    scalars, TOML inline tables, arrays and multi-line strings all went to
+    the remote repo in plaintext with exit code 0.
+    """
+
+    S = "SENTINEL-BUG010-PLAINTEXT-SECRET"
+
+    def _yaml(self, text):
+        from ms_agent.agent_hub._workspace import scrub_yaml_secrets
+        return scrub_yaml_secrets(text, mcp_block_keys=("mcp_servers", ))
+
+    def _toml(self, text):
+        from ms_agent.agent_hub.frameworks.openhuman import OpenhumanWorkspace
+        return OpenhumanWorkspace(agent_name="default")._scrub_toml_secrets(
+            text)
+
+    def test_yaml_spellings_all_scrubbed(self):
+        cases = {
+            "flow_env":
+            "mcp_servers:\n  fetch:\n    env: {TAVILY_API_KEY: %s}\n" % self.S,
+            "flow_top": "llm: {api_key: %s, model: qwen3-max}\n" % self.S,
+            "block_scalar": "api_key: |\n  %s\n" % self.S,
+            "folded_scalar": "api_key: >\n  %s\n" % self.S,
+            "baseline": "api_key: %s\n" % self.S,
+        }
+        leaked = [n for n, t in cases.items() if self.S in self._yaml(t)]
+        self.assertEqual(leaked, [], f"YAML spellings leaked: {leaked}")
+
+    def test_toml_spellings_all_scrubbed(self):
+        cases = {
+            "inline_table": 'provider = { api_key = "%s" }\n' % self.S,
+            "array": 'tokens = ["%s"]\n' % self.S,
+            "multiline": "secret = '''\n%s\n'''\n" % self.S,
+            "nested_inline": 'model = { auth = { token = "%s" } }\n' % self.S,
+            "baseline": 'api_key = "%s"\n' % self.S,
+        }
+        leaked = [n for n, t in cases.items() if self.S in self._toml(t)]
+        self.assertEqual(leaked, [], f"TOML spellings leaked: {leaked}")
+
+    def test_non_secret_content_preserved(self):
+        """Comments, key order and non-secret pairs stay byte-identical."""
+        yaml_in = ("# comment\nmodel: qwen3-max\n"
+                   "llm: {model: qwen3-max, temperature: 0.7}\n")
+        self.assertEqual(self._yaml(yaml_in), yaml_in)
+        toml_in = ('# comment\nname = "bot"\n'
+                   'provider = { model = "qwen3-max", timeout = 30 }\n')
+        self.assertEqual(self._toml(toml_in), toml_in)
+
+    def test_http_credential_key_names_recognized(self):
+        """Regression (BUG-016): plain ``key: value`` lines with common HTTP
+        credential key names (authorization / bearer / cookie / session_id)
+        leaked because the vocabulary only knew key/token/secret suffixes."""
+        from ms_agent.agent_hub._workspace import is_secret_key
+        for key in ("authorization", "Authorization", "bearer", "cookie",
+                    "cookies", "set-cookie", "session_id", "sessionid",
+                    "x-api-key"):
+            self.assertTrue(is_secret_key(key), f"{key} not recognized")
+            leaked = self._yaml(f"{key}: SENTINEL-BUG016-TOKEN\n")
+            self.assertNotIn("SENTINEL-BUG016-TOKEN", leaked, key)
+        # No over-reach on ordinary keys.
+        for key in ("model", "session_timeout", "author", "bookkeeper"):
+            self.assertFalse(is_secret_key(key), f"{key} wrongly flagged")
+
+
+class TestFailClosedUploadSanitize(unittest.TestCase):
+    """Malformed config files must be REFUSED on upload, not pushed verbatim.
+
+    Regression (BUG-012): a syntactically broken ``agent.json`` /
+    ``settings.json`` skipped sanitizing and went to the remote repo with
+    plaintext keys and exit code 0.  Upload now fails closed; the inbound
+    (download) direction keeps its best-effort pass-through.
+    """
+
+    S = "SENTINEL-BUG012-PLAINTEXT-KEY"
+    BROKEN = '{"id": "bot", "api_key": "%s",,,'
+
+    def test_qwenpaw_broken_agent_json_refused_on_upload(self):
+        spec = QwenpawWorkspace(agent_name="default")
+        with self.assertRaises(ValueError):
+            spec.sanitize_outbound_file("agent.json",
+                                        (self.BROKEN % self.S).encode())
+
+    def test_msagent_broken_settings_json_refused_on_upload(self):
+        from ms_agent.agent_hub.frameworks.ms_agent import MsAgentWorkspace
+        spec = MsAgentWorkspace(agent_name="default")
+        with self.assertRaises(ValueError):
+            spec.sanitize_outbound_file("settings.json",
+                                        (self.BROKEN % self.S).encode())
+
+    def test_inbound_direction_still_best_effort(self):
+        """Download keeps pass-through: a broken remote file must not abort
+        the whole download (it adds no new exposure when written locally)."""
+        spec = QwenpawWorkspace(agent_name="default")
+        raw = (self.BROKEN % self.S).encode()
+        self.assertEqual(spec.sanitize_inbound_file("agent.json", raw), raw)
+
+    @mock.patch("pathlib.Path.home")
+    def test_cmd_upload_fails_with_clear_message(self, mock_home):
+        """End-to-end: upload aborts with exit code 1 BEFORE any network or
+        credential use, and the message names the broken file."""
+        from ms_agent.agent_hub._commands import cmd_upload
+        with tempfile.TemporaryDirectory() as td:
+            mock_home.return_value = Path(td)
+            ws = Path(td) / "ws"
+            ws.mkdir()
+            (ws / "agent.json").write_text(self.BROKEN % self.S)
+            rc = cmd_upload("qwenpaw", name="default", local_dir=str(ws),
+                            repo="owner/broken-demo")
+            self.assertEqual(rc, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

**脱敏 / 安全**
1. qwenpaw `agent.json` 的 MCP 配置只认 `mcp.clients` 一种写法，`mcp_clients` / `mcpClients` 下的 env 密钥会明文上传，改为任意位置的 env 字典统一清空
2. `agent.json` / `settings.json` 语法损坏时脱敏被跳过、明文密钥原样上传，改为解析失败直接拒绝上传并报错（fail-closed）
3. 脱敏词表补充 `authorization` / `bearer` / `cookie` / `session_id` 等最常见 HTTP 凭据键名
4. openhuman TOML 脱敏只处理简单 `key = value`，补齐内联表、数组、多行字符串三种写法中的密钥清除
5. restore 解压外部 zip 时不做文件过滤和入站脱敏，非约定文件与明文密钥会直接写入工作区，已对齐 download 的入站规则

**CLI 命令行为**
6. `agent stop` 用宽子串 `pgrep -f 'agent watch'` 扫杀，会误杀无关进程且根本匹配不到真 daemon，改为精确 argv 标记 + 杀前 pid 身份校验
7. 下载走文本模式导致 PNG 等二进制资产字节损坏，改为字节下载、UTF-8 可解码时才按文本处理
8. restore 遇到损坏 zip 抛裸 `BadZipFile` traceback，改为前置校验并给出受控错误提示
9. `download --target-framework` 与本地 `convert` 结果不一致（多写默认模板），两个入口已同参对齐
10. 同一秒内两次备份写同名 zip 导致前一个恢复点被覆盖，文件名冲突时追加递增序号
11. 备份文件名解析未按注册框架名锚定，`ms-agent` 自带的 `-` 被误当分隔符，导致 `backups -f` 过滤和 restore 定位错误

**内置技能判定**
12. SKILL.md 带 `license` 字段被误判为内置技能导致用户开源技能整目录丢弃，已删除该判据
13. `metadata.<产品名>` 裸键存自定义参数被误判内置，改为仅在带安装提示形状时才判内置
14. 内置技能 frontmatter YAML 损坏时被误放行为用户技能导致内置资产外传，manifest 目录名检查提前到解析之前

**合并引擎**
15. convert/download 会静默覆盖目标已有的同名技能，改为跳过并输出 Skipped 提示
16. 同名 `##` 章节合并只保留最后一段，改为按出现顺序全部保留
17. 用户新增内容提取用全局行集合去重，用户段落里复用的模板行被误删（同时导致重复 convert 后内容清空），改用位置对比算法
18. HEARTBEAT 合并时新增任务被写入两次，改为只补结果中真正缺失的任务
19. HEARTBEAT 多行 `<!-- -->` 注释的中间行被当成任务插入任务区，任务提取已跟踪注释块
20. 目标模板没有 `## Active Tasks` 章节时用户任务被静默丢弃，改为新建章节兜底保留

**测试基建**
21. 在线用例 `test_03_qwenpaw_all_bidirectional` 裸查一次远端易被服务端建仓延迟误伤，改为与其他用例一致的轮询等待