### PR TITLE
Fix/runtime robustness

### DIFF
--- a/ms_agent/agent/llm_agent.py
+++ b/ms_agent/agent/llm_agent.py
@@ -59,8 +59,15 @@ INTERRUPTED_PLACEHOLDER = '[interrupted]'
 _INTERRUPTED_TOOL_RESULT = '[Interrupted: tool execution was cancelled]'
 
 
-def build_partial_round_records(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Turn an interrupted round's in-memory rows into protocol-valid log records.
+def build_partial_round_records(
+        rows: List[Dict[str, Any]],
+        marker: str = 'interrupted') -> List[Dict[str, Any]]:
+    """Turn an unfinished round's in-memory rows into protocol-valid log records.
+
+    ``marker`` is the boolean key stamped on every produced record, naming *why*
+    the round ended early: ``interrupted`` (user Stop / cancellation) or
+    ``errored`` (the turn raised). UIs badge these differently, so an API
+    failure must not be sealed as an interruption.
 
     ``rows`` are the ``_msg_to_dict`` serializations of ``messages[pre_step_len:]``
     at cancellation time. Rules (each keeps replay valid on BOTH transports):
@@ -79,7 +86,7 @@ def build_partial_round_records(rows: List[Dict[str, Any]]) -> List[Dict[str, An
       with no content and no kept calls gets the neutral placeholder content so
       the turn reads as closed (an empty assistant block would be rejected on
       Anthropic replay, and a dangling user row would be re-answered on resume).
-    - every row is flagged ``interrupted: true`` — an extra key that survives in
+    - every row is flagged ``<marker>: true`` — an extra key that survives in
       the log for UI replay but is filtered out of the LLM context rebuild.
     """
     present_results = {
@@ -89,7 +96,7 @@ def build_partial_round_records(rows: List[Dict[str, Any]]) -> List[Dict[str, An
     records: List[Dict[str, Any]] = []
     for row in rows:
         rec = dict(row)
-        rec['interrupted'] = True
+        rec[marker] = True
         if rec.get('role') != 'assistant':
             records.append(rec)
             continue
@@ -130,14 +137,14 @@ def build_partial_round_records(rows: List[Dict[str, Any]]) -> List[Dict[str, An
                 'tool_call_id': tc.get('id'),
                 'name': tc.get('tool_name', ''),
                 'is_error': True,
-                'interrupted': True,
+                marker: True,
             })
     if not records:
         records.append({
             'role': 'assistant',
             'content': INTERRUPTED_PLACEHOLDER,
             'content_placeholder': True,
-            'interrupted': True,
+            marker: True,
         })
     return records
 
@@ -1980,16 +1987,24 @@ class LLMAgent(Agent):
             d['tokens'] = prompt_tokens + completion_tokens
         return d
 
-    def _persist_partial_round(self, messages: List[Message],
-                               pre_step_len: int) -> None:
-        """Seal an interrupted round into the SessionLog (best-effort).
+    def _persist_partial_round(self,
+                               messages: List[Message],
+                               pre_step_len: int,
+                               marker: str = 'interrupted') -> None:
+        """Seal an unfinished round into the SessionLog (best-effort).
 
-        Called from run_loop's cancellation handler, where the normal
-        round-boundary persistence can no longer run. Serializes the round's
-        in-memory rows and appends the protocol-repaired records built by
-        :func:`build_partial_round_records`. Synchronous file I/O only (safe
-        inside a cancelled task); never raises — sealing must not break the
-        cancellation unwind.
+        Called from run_loop's cancellation handler AND its exception handler,
+        where the normal round-boundary persistence can no longer run.
+        Serializes the round's in-memory rows and appends the protocol-repaired
+        records built by :func:`build_partial_round_records`. Synchronous file
+        I/O only (safe inside a cancelled task); never raises — sealing must not
+        break the unwind.
+
+        Sealing is not cosmetic: without it the log tail stays on a ``user`` or
+        ``tool`` row, and the next resume rebuilds that same round and re-calls
+        the model instead of reading the user's new prompt (see run_loop's
+        ``load_cache`` guard). ``marker`` records why the round ended —
+        ``interrupted`` for Stop, ``errored`` for a raised turn.
         """
         if self.session_log is None:
             return
@@ -2018,7 +2033,7 @@ class LLMAgent(Agent):
             rows = [
                 self._msg_to_dict(msg) for msg in messages[pre_step_len:]
             ]
-            for record in build_partial_round_records(rows):
+            for record in build_partial_round_records(rows, marker=marker):
                 self.session_log.append(record)
         except Exception:
             logger.warning('persist partial round failed', exc_info=True)
@@ -2034,6 +2049,11 @@ class LLMAgent(Agent):
         Args:
             messages: Input prompt string or list of Message objects.
         """
+        # Bound BEFORE the try so the exception handler can always read it:
+        # setup (agent/LLM construction, credential resolution) raises well
+        # before the round loop, and an unbound local there would turn a clean
+        # provider error into an UnboundLocalError. None = no round to seal.
+        pre_step_len: Optional[int] = None
         try:
             self.max_chat_round = getattr(self.config, 'max_chat_round',
                                           LLMAgent.DEFAULT_MAX_CHAT_ROUND)
@@ -2266,6 +2286,17 @@ class LLMAgent(Agent):
             import traceback
 
             logger.warning(traceback.format_exc())
+            # Seal the round FIRST. A raised turn leaves the log tail on a
+            # `user`/`tool` row, and run_loop's resume guard only skips the
+            # model call when the tail is `assistant` — so the next request
+            # rebuilds this same round, re-sends the identical failing context,
+            # and never reaches after_tool_call (which is what drains the queued
+            # prompt). The user sees the turn "loop" while every resend is
+            # silently discarded. Sealing closes the round, so the rebuilt agent
+            # blocks on read_prompt and consumes the new message instead.
+            if pre_step_len is not None:
+                self._persist_partial_round(
+                    messages, pre_step_len, marker='errored')
             if self._event_sink is not None:
                 # A run_loop turn-abort is non-recoverable (the turn produced no
                 # usable assistant output); mark it so live == persisted/replay.

--- a/ms_agent/agent/llm_agent.py
+++ b/ms_agent/agent/llm_agent.py
@@ -40,7 +40,8 @@ from ms_agent.ui.events import (ContentDelta, ContentEnd, ContextCompacted,
                                 ReasoningDelta, ReasoningEnded,
                                 ReasoningStarted, ToolCallCompleted,
                                 ToolCallStarted, TurnCompleted, UsageInfo)
-from ms_agent.utils import async_retry, read_history, save_history
+from ms_agent.utils import (async_retry, is_retryable_error, read_history,
+                            save_history)
 from ms_agent.utils.constants import DEFAULT_TAG, DEFAULT_USER
 from ms_agent.utils.logger import get_logger
 from ms_agent.utils.snapshot import take_snapshot
@@ -1535,7 +1536,11 @@ class LLMAgent(Agent):
         messages.append(Message(role='user', content=body))
         return messages
 
-    @async_retry(max_attempts=Agent.retry_count, delay=1.0)
+    # retry_if: a hard 4xx (bad payload, content filter, auth) is a verdict on
+    # the request, not a transient fault — retrying it 5× only adds ~40s of
+    # backoff before the same failure surfaces.
+    @async_retry(
+        max_attempts=Agent.retry_count, delay=1.0, retry_if=is_retryable_error)
     async def step(
         self, messages: List[Message]
     ) -> AsyncGenerator[List[Message], Any]:  # type: ignore

--- a/ms_agent/llm/transport/openai_compat.py
+++ b/ms_agent/llm/transport/openai_compat.py
@@ -171,6 +171,14 @@ class OpenAICompatTransport(Transport):
             cache_indice = max(cache_indices) if cache_indices else None
 
         openai_messages = []
+        # Order-matched fallback for a tool row that reaches us without its id.
+        # OpenAI-compatible gateways reject such a message outright
+        # ("missing field `tool_call_id`"), killing the whole turn, so pair it
+        # with the preceding assistant turn's calls instead. The Anthropic
+        # transport has carried the same guard for a while; this keeps the two
+        # symmetric. Note `to_dict_clean()` omits falsy values, so a None/'' id
+        # disappears from the dict entirely rather than arriving as None.
+        pending_tool_ids: List[str] = []
         for idx, message in enumerate(messages):
             if isinstance(message, Message):
                 if isinstance(message.content, str):
@@ -206,6 +214,22 @@ class OpenAICompatTransport(Transport):
                     and formatted_message.get('tool_calls')
                     and not content):
                 formatted_message['content'] = None
+
+            role = formatted_message.get('role')
+            if role == 'assistant':
+                pending_tool_ids = [
+                    tc.get('id') for tc in (formatted_message.get('tool_calls')
+                                            or []) if isinstance(tc, dict)
+                    and tc.get('id')
+                ]
+            elif role == 'tool' and not formatted_message.get('tool_call_id'):
+                if pending_tool_ids:
+                    formatted_message['tool_call_id'] = pending_tool_ids.pop(0)
+                else:
+                    logger.warning(
+                        'tool message has no tool_call_id and no preceding '
+                        'assistant tool_calls to match it against; the provider '
+                        'will likely reject this request')
 
             openai_messages.append(formatted_message)
         return openai_messages

--- a/ms_agent/memory/unified/orchestrator.py
+++ b/ms_agent/memory/unified/orchestrator.py
@@ -12,6 +12,9 @@ from typing import Any, Dict, List, Optional
 
 from ms_agent.llm.utils import Message
 from ms_agent.memory.base import Memory
+# Single canonical deserializer, shared with ContextAssembler. A second local
+# copy previously drifted and silently dropped `tool_call_id` / `name`.
+from ms_agent.session.context_assembler import _dicts_to_messages
 from ms_agent.utils.logger import get_logger
 from .config import MemoryConfig
 from .protocols import MemoryBackend, MemoryEntry
@@ -181,6 +184,15 @@ class MemoryOrchestrator(Memory):
 
 
 def _messages_to_dicts(messages: List[Message]) -> List[Dict[str, Any]]:
+    """Serialize for ``backend.inject()`` — must be lossless.
+
+    This round-trip (``run()``: messages -> dicts -> inject -> messages) runs on
+    EVERY turn, so any field dropped here is dropped from the live LLM context,
+    not just from storage. ``tool_call_id`` in particular is mandatory on the
+    wire for ``role='tool'`` rows: losing it makes OpenAI-compatible providers
+    reject the request with ``missing field 'tool_call_id'``. Keep this the
+    exact inverse of ``_dicts_to_messages`` below.
+    """
     result: List[Dict[str, Any]] = []
     for m in messages:
         if isinstance(m, dict):
@@ -189,24 +201,15 @@ def _messages_to_dicts(messages: List[Message]) -> List[Dict[str, Any]]:
             d: Dict[str, Any] = {'role': m.role, 'content': m.content or ''}
             if m.tool_calls:
                 d['tool_calls'] = m.tool_calls
+            if m.tool_call_id:
+                d['tool_call_id'] = m.tool_call_id
+            if m.name:
+                d['name'] = m.name
+            if m.reasoning_content:
+                d['reasoning_content'] = m.reasoning_content
+            if m.reasoning_signature:
+                d['reasoning_signature'] = m.reasoning_signature
             result.append(d)
         else:
             result.append({'role': 'user', 'content': str(m)})
-    return result
-
-
-def _dicts_to_messages(dicts: List[Dict[str, Any]]) -> List[Message]:
-    result: List[Message] = []
-    for d in dicts:
-        if isinstance(d, Message):
-            result.append(d)
-        elif isinstance(d, dict):
-            result.append(
-                Message(
-                    role=d.get('role', 'user'),
-                    content=d.get('content', ''),
-                    tool_calls=d.get('tool_calls'),
-                ))
-        else:
-            result.append(Message(role='user', content=str(d)))
     return result

--- a/ms_agent/session/session_log.py
+++ b/ms_agent/session/session_log.py
@@ -103,7 +103,20 @@ class SessionLog:
         turn-level / API errors that must NOT go back to the model (tool-call
         errors stay as ordinary ``role="tool"`` messages instead).  ``event``
         typically carries ``message``, ``error_type``, ``recoverable``, ``round``.
+
+        Idempotent per (round, message): a round that is retried or replayed
+        must not stack identical records. A wedged turn used to append one per
+        attempt, growing a log of dozens of copies of the same failure and
+        making replay unreadable. Dedup needs a ``round`` to key on; without one
+        every call is recorded (callers that omit it are opting out).
         """
+        rnd = event.get('round')
+        if rnd is not None:
+            message = event.get('message')
+            for prior in self.get_errors():
+                if (prior.get('round') == rnd
+                        and prior.get('message') == message):
+                    return
         seq = self._next_seq()
         record = {
             "_type": "error",

--- a/ms_agent/tools/code/local_code_executor.py
+++ b/ms_agent/tools/code/local_code_executor.py
@@ -332,6 +332,18 @@ class LocalCodeExecutionTool(ToolBase):
                 'HOME': os.environ.get('HOME', ''),
                 'LANG': os.environ.get('LANG', ''),
             }
+            if os.name == 'nt':
+                # ``create_subprocess_shell`` uses the native Windows command
+                # processor. Keep the non-secret OS/user variables that cmd
+                # and programs using temporary/profile directories require.
+                for key in (
+                        'SYSTEMROOT', 'WINDIR', 'COMSPEC', 'PATHEXT', 'TEMP',
+                        'TMP', 'TMPDIR', 'USERPROFILE', 'HOMEDRIVE',
+                        'HOMEPATH', 'USERNAME', 'APPDATA', 'LOCALAPPDATA',
+                        'PROGRAMDATA', 'OS', 'PROCESSOR_ARCHITECTURE'):
+                    value = os.environ.get(key)
+                    if value is not None:
+                        env[key] = value
 
         if not self.tool_config or not hasattr(self.tool_config, field):
             return env
@@ -589,7 +601,12 @@ class LocalCodeExecutionTool(ToolBase):
                 indent=2)
 
     def _prepare_shell_command(self, command: str) -> str:
-        """Wrap composite shell input in ``sh -lc`` when needed (matches sandbox behavior)."""
+        """Use the native Windows shell; wrap composite POSIX input when needed."""
+        if os.name == 'nt':
+            # asyncio.create_subprocess_shell delegates to cmd.exe on Windows;
+            # wrapping native syntax in a usually unavailable POSIX shell
+            # makes otherwise valid compound commands fail.
+            return command
         shell_meta = ('&&', '||', '|', ';', '>', '<', '`', '$(', 'cd ',
                       'export ')
         already_wrapped = command.lstrip().startswith(

--- a/ms_agent/utils/__init__.py
+++ b/ms_agent/utils/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
-from .llm_utils import async_retry, retry
+from .llm_utils import async_retry, is_retryable_error, retry
 from .logger import get_logger
 from .prompt import get_fact_retrieval_prompt
 from .utils import (assert_package_exist, enhance_error, read_history,

--- a/ms_agent/utils/llm_utils.py
+++ b/ms_agent/utils/llm_utils.py
@@ -1,14 +1,57 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import asyncio
 import functools
+import re
 import time
-from typing import Any, AsyncGenerator, Callable, Tuple, Type, TypeVar, Union
+from typing import (Any, AsyncGenerator, Callable, Optional, Tuple, Type,
+                    TypeVar, Union)
 
 from .logger import get_logger
 
 logger = get_logger()
 
 T = TypeVar('T')
+
+# 4xx statuses that CAN succeed on a resend: request timeout, lock conflict,
+# too-early, and rate limiting. Every other 4xx is a verdict on the request
+# itself — resending the identical payload just buys the same rejection.
+_RETRYABLE_CLIENT_STATUSES = frozenset({408, 409, 425, 429})
+
+# Providers surface the status inconsistently: the openai/anthropic SDKs expose
+# `status_code`, while gateways often only put it in the message
+# ("APIError: <400> ...", "Error code: 400 - {...}").
+_STATUS_IN_TEXT = re.compile(r'<(\d{3})>|(?:error\s+)?code[:=]?\s*(\d{3})\b',
+                             re.IGNORECASE)
+
+
+def http_status_of(exc: BaseException) -> Optional[int]:
+    """Best-effort HTTP status for a provider exception, or None if unknown."""
+    for attr in ('status_code', 'http_status', 'status'):
+        value = getattr(exc, attr, None)
+        if isinstance(value, int) and 100 <= value <= 599:
+            return value
+    match = _STATUS_IN_TEXT.search(str(exc))
+    if match:
+        status = int(match.group(1) or match.group(2))
+        if 100 <= status <= 599:
+            return status
+    return None
+
+
+def is_retryable_error(exc: BaseException) -> bool:
+    """Whether resending the same request could plausibly succeed.
+
+    Unknown/None status keeps the historical behaviour (retry), so transient
+    network faults are unaffected. Only an identifiable, non-transient 4xx
+    fails fast — previously a hard 400 (bad payload, content filter, missing
+    field) burned all five attempts plus 15s of backoff before surfacing.
+    """
+    status = http_status_of(exc)
+    if status is None:
+        return True
+    if 400 <= status < 500:
+        return status in _RETRYABLE_CLIENT_STATUSES
+    return True
 
 
 def retry(max_attempts: int = 3,
@@ -54,8 +97,14 @@ def async_retry(max_attempts: int = 3,
                 delay: float = 1.0,
                 backoff_factor: float = 2.0,
                 exceptions: Union[Type[Exception], Tuple[Type[Exception],
-                                                         ...]] = Exception):
-    """Retry doing something"""
+                                                         ...]] = Exception,
+                retry_if: Optional[Callable[[BaseException], bool]] = None):
+    """Retry doing something.
+
+    ``retry_if`` short-circuits the loop for exceptions that cannot succeed on
+    a resend (see :func:`is_retryable_error`); the exception is still raised,
+    just without burning the remaining attempts and their backoff.
+    """
 
     def decorator(func: Callable[..., T]) -> Callable[..., T]:
 
@@ -73,6 +122,12 @@ def async_retry(max_attempts: int = 3,
                     import traceback
                     logger.warning(traceback.format_exc())
                     last_exception = e
+                    if retry_if is not None and not retry_if(e):
+                        logger.error(
+                            f'{func.__name__} failed unrecoverably on attempt '
+                            f'{attempt}/{max_attempts}; not retrying. '
+                            f'Exception message: {e}')
+                        break
                     if attempt < max_attempts:
                         logger.warning(
                             f'Attempt {attempt}/{max_attempts} fails: {func.__name__}. '

--- a/tests/agent/test_partial_round.py
+++ b/tests/agent/test_partial_round.py
@@ -185,3 +185,67 @@ def test_reasoning_duration_finalized_when_cancelled_mid_reasoning():
     import time
     dur = _persisted_reasoning_duration(time.monotonic() - 3.0, None)
     assert dur is not None and dur >= 2
+
+
+# --- sealing a round that RAISED (not a user Stop) -----------------------
+
+
+def test_errored_marker_replaces_interrupted():
+    # run_loop's exception handler seals with marker='errored'. UIs badge
+    # `interrupted` as a user Stop, so an API failure must not borrow that key.
+    records = build_partial_round_records([], marker='errored')
+    assert records == [{
+        'role': 'assistant',
+        'content': INTERRUPTED_PLACEHOLDER,
+        'content_placeholder': True,
+        'errored': True,
+    }]
+    assert 'interrupted' not in records[0]
+
+
+def test_errored_marker_applies_to_synthesized_tool_results():
+    records = build_partial_round_records(
+        [{'role': 'assistant', 'content': '',
+          'tool_calls': [{'id': 'c1', 'arguments': '{}', 'tool_name': 'grep'}]}],
+        marker='errored')
+    assert [r['role'] for r in records] == ['assistant', 'tool']
+    assert all(r.get('errored') is True for r in records)
+    assert not any('interrupted' in r for r in records)
+
+
+def test_error_seal_closes_dangling_tool_tail():
+    """The regression that made failed turns look like an infinite loop.
+
+    A raised turn used to leave the log tail on a `tool` row. run_loop's resume
+    guard only skips the model call when the tail is `assistant`, so the next
+    request replayed the same round with the same failing context and never
+    drained the queued prompt — every resend was silently dropped.
+    """
+    from ms_agent.agent.llm_agent import LLMAgent
+
+    class _Log:
+
+        def __init__(self, rows):
+            self.rows = list(rows)
+
+        def append(self, rec):
+            self.rows.append(rec)
+            return len(self.rows)
+
+    # Tail as persisted by the round that then blew up on the next LLM call.
+    stub = LLMAgent.__new__(LLMAgent)
+    stub.session_log = _Log([
+        {'role': 'user', 'content': '搜一下今天的热点新闻'},
+        {'role': 'assistant', 'content': '',
+         'tool_calls': [{'id': 'c1', 'arguments': '{}', 'tool_name': 'search'}]},
+        {'role': 'tool', 'content': 'results', 'tool_call_id': 'c1'},
+    ])
+    stub._reasoning_started_at = None
+    stub._last_reasoning_duration = None
+    assert stub.session_log.rows[-1]['role'] == 'tool'  # the poisoned state
+
+    # step() raised before yielding anything -> empty segment.
+    LLMAgent._persist_partial_round(stub, [], 0, marker='errored')
+
+    assert stub.session_log.rows[-1]['role'] == 'assistant'
+    assert stub.session_log.rows[-1]['errored'] is True

--- a/tests/memory/test_unified_memory.py
+++ b/tests/memory/test_unified_memory.py
@@ -262,6 +262,31 @@ class TestResumeMessageRoundTrip:
         assert msgs[1].tool_call_id == "call_1"
         assert msgs[1].name == "search"
 
+    def test_memory_orchestrator_round_trip_preserves_tool_fields(self):
+        """The unified-memory round-trip runs on EVERY turn, in-memory, before
+        the LLM call — so a field dropped there is dropped from the live
+        request. This previously regressed independently of the assembler
+        (the test above imported the assembler's copy and never covered it),
+        and OpenAI-compatible providers answered with
+        ``missing field 'tool_call_id'``.
+        """
+        from ms_agent.memory.unified.orchestrator import (_dicts_to_messages,
+                                                          _messages_to_dicts)
+        from ms_agent.llm.utils import Message
+
+        msgs = [
+            Message(role="assistant", content="",
+                    tool_calls=[{"id": "call_1", "type": "function"}]),
+            Message(role="tool", content="result",
+                    tool_call_id="call_1", name="search"),
+        ]
+        out = _dicts_to_messages(_messages_to_dicts(msgs))
+        assert out[1].tool_call_id == "call_1"
+        assert out[1].name == "search"
+        # And it must actually reach the wire: to_dict_clean() drops falsy
+        # values, so a lost id disappears from the payload entirely.
+        assert out[1].to_dict_clean()["tool_call_id"] == "call_1"
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # 2. ViewStrategies

--- a/tests/memory/test_unified_memory.py
+++ b/tests/memory/test_unified_memory.py
@@ -1696,3 +1696,40 @@ class TestEndToEnd:
             assert len(log.get_all_messages()) == 4
         finally:
             loop.close()
+
+
+class TestSessionLogErrorDedup:
+    """record_error is idempotent per (round, message).
+
+    A wedged turn used to append one identical record per retry/replay attempt
+    (observed: five copies of the same 400, all round 15), making replay
+    unreadable. Callers that omit ``round`` opt out of dedup on purpose — they
+    have no round identity to key on.
+    """
+
+    def setup_method(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_same_round_same_message_recorded_once(self):
+        log = SessionLog(self.tmpdir, session_key="err_dedup")
+        for _ in range(5):
+            log.record_error({
+                "message": "APIError: <400> boom",
+                "recoverable": False,
+                "round": 15,
+            })
+        assert len(log.get_errors()) == 1
+
+    def test_round_and_message_changes_are_kept(self):
+        log = SessionLog(self.tmpdir, session_key="err_kept")
+        log.record_error({"message": "APIError: boom", "round": 15})
+        log.record_error({"message": "APIError: boom", "round": 16})
+        log.record_error({"message": "different failure", "round": 15})
+        assert len(log.get_errors()) == 3
+
+    def test_callers_without_a_round_opt_out_of_dedup(self):
+        log = SessionLog(self.tmpdir, session_key="err_optout")
+        log.record_error({"message": "no round identity"})
+        log.record_error({"message": "no round identity"})
+        assert len(log.get_errors()) == 2

--- a/tests/tools/test_local_code_executor_windows.py
+++ b/tests/tools/test_local_code_executor_windows.py
@@ -1,0 +1,47 @@
+import os
+from unittest import mock
+
+from ms_agent.tools.code.local_code_executor import LocalCodeExecutionTool
+
+
+def _bare_tool() -> LocalCodeExecutionTool:
+    """Build a unit-test instance without starting kernels or checking deps."""
+    tool = LocalCodeExecutionTool.__new__(LocalCodeExecutionTool)
+    tool.tool_config = None
+    return tool
+
+
+def test_composite_command_uses_native_windows_shell():
+    command = 'cd work && echo ok > result.txt'
+    with mock.patch('ms_agent.tools.code.local_code_executor.os.name', 'nt'):
+        assert _bare_tool()._prepare_shell_command(command) == command
+
+
+def test_sanitized_env_keeps_windows_runtime_variables():
+    windows_env = {
+        'PATH': r'C:\Windows\System32',
+        'SYSTEMROOT': r'C:\Windows',
+        'WINDIR': r'C:\Windows',
+        'COMSPEC': r'C:\Windows\System32\cmd.exe',
+        'PATHEXT': '.COM;.EXE;.BAT;.CMD',
+        'TEMP': r'C:\Users\tester\AppData\Local\Temp',
+        'TMP': r'C:\Users\tester\AppData\Local\Temp',
+        'USERPROFILE': r'C:\Users\tester',
+        'HOMEDRIVE': 'C:',
+        'HOMEPATH': r'\Users\tester',
+        'USERNAME': 'tester',
+        'APPDATA': r'C:\Users\tester\AppData\Roaming',
+        'LOCALAPPDATA': r'C:\Users\tester\AppData\Local',
+        'SECRET_TOKEN': 'must-not-leak',
+    }
+    with mock.patch.dict(os.environ, windows_env, clear=True), mock.patch(
+            'ms_agent.tools.code.local_code_executor.os.name', 'nt'):
+        env = _bare_tool()._build_env('shell_env', inherit=False)
+
+    for key in (
+            'SYSTEMROOT', 'WINDIR', 'COMSPEC', 'PATHEXT', 'TEMP', 'TMP',
+            'USERPROFILE', 'HOMEDRIVE', 'HOMEPATH', 'USERNAME', 'APPDATA',
+            'LOCALAPPDATA'):
+        assert env[key] == windows_env[key]
+    assert env['INHERITED_FROM_LOCAL'] == 'False'
+    assert 'SECRET_TOKEN' not in env

--- a/tests/utils/test_retry_classification.py
+++ b/tests/utils/test_retry_classification.py
@@ -1,0 +1,109 @@
+"""async_retry's ``retry_if`` gate: don't burn attempts on unrecoverable 4xx.
+
+A hard 400 (bad payload, missing field, content filter) is a verdict on the
+request — resending the identical body five times only adds ~15s of backoff
+before the same failure surfaces. Transient faults must keep retrying.
+"""
+import asyncio
+
+import pytest
+from ms_agent.utils import async_retry, is_retryable_error
+from ms_agent.utils.llm_utils import http_status_of
+
+
+class _ApiError(Exception):
+    """Stand-in for a provider SDK error, with or without ``status_code``."""
+
+    def __init__(self, message, status_code=None):
+        super().__init__(message)
+        if status_code is not None:
+            self.status_code = status_code
+
+
+@pytest.mark.parametrize(
+    'exc, expected',
+    [
+        # Real strings observed in production, where the status is only in text.
+        (_ApiError('APIError: <400> InternalError.Algo.DataInspectionFailed: '
+                   'Output data may contain inappropriate content.'), 400),
+        (_ApiError("Error code: 400 - {'error': {'message': 'missing field "
+                   "`tool_call_id`'}}"), 400),
+        # Structured SDK errors.
+        (_ApiError('boom', 429), 429),
+        (_ApiError('boom', 503), 503),
+        # Nothing status-like.
+        (ConnectionError('Connection reset by peer'), None),
+    ],
+)
+def test_http_status_extraction(exc, expected):
+    assert http_status_of(exc) == expected
+
+
+@pytest.mark.parametrize('status', [400, 401, 403, 404, 422])
+def test_client_errors_are_not_retryable(status):
+    assert is_retryable_error(_ApiError('boom', status)) is False
+
+
+@pytest.mark.parametrize('status', [408, 409, 425, 429, 500, 502, 503])
+def test_transient_and_server_errors_stay_retryable(status):
+    assert is_retryable_error(_ApiError('boom', status)) is True
+
+
+@pytest.mark.parametrize(
+    'exc',
+    [ConnectionError('reset'),
+     TimeoutError('timed out'),
+     Exception('something odd')])
+def test_unknown_errors_keep_retrying(exc):
+    # Conservative default: an unidentifiable failure behaves as before.
+    assert is_retryable_error(exc) is True
+
+
+def _run(fn):
+    async def drive():
+        async for _ in fn():
+            pass
+
+    with pytest.raises(Exception):
+        asyncio.run(drive())
+
+
+def test_unrecoverable_error_uses_exactly_one_attempt():
+    calls = []
+
+    @async_retry(max_attempts=5, delay=10.0, retry_if=is_retryable_error)
+    async def boom():
+        calls.append(1)
+        raise _ApiError('APIError: <400> DataInspectionFailed')
+        yield  # pragma: no cover - makes this an async generator
+
+    _run(boom)
+    # delay=10.0 would make a retrying implementation take >=10s; one attempt
+    # also proves no backoff was slept.
+    assert len(calls) == 1
+
+
+def test_transient_error_still_exhausts_attempts():
+    calls = []
+
+    @async_retry(max_attempts=3, delay=0.01, retry_if=is_retryable_error)
+    async def flaky():
+        calls.append(1)
+        raise ConnectionError('reset')
+        yield  # pragma: no cover
+
+    _run(flaky)
+    assert len(calls) == 3
+
+
+def test_without_retry_if_behaviour_is_unchanged():
+    calls = []
+
+    @async_retry(max_attempts=3, delay=0.01)
+    async def boom():
+        calls.append(1)
+        raise _ApiError('APIError: <400> DataInspectionFailed')
+        yield  # pragma: no cover
+
+    _run(boom)
+    assert len(calls) == 3


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

- **Fix tool_call_id loss in unified memory round-trip** — the orchestrator kept a lossy local
  copy of the message (de)serializers that dropped `tool_call_id`/`name`, so any turn with tool
  history + memory enabled was rejected by OpenAI-compatible gateways (400 `missing field tool_call_id`).
- **Pair tool results with pending calls in the openai-compat transport** — order-matched fallback
  when a tool message arrives without its id, mirroring the guard the Anthropic transport already has.
- **Seal errored rounds** — a turn that raised used to leave the log tail on a `user`/`tool` row,
  so the next request replayed the same failing round and silently discarded the new prompt;
  the exception path now persists a protocol-valid `errored` seal (Stop/interrupt sealing already existed).
- **Skip retries on non-retryable 4xx** — a hard client error (bad payload, auth, content filter)
  was retried 5x with backoff (~40s wasted per failure); it now fails fast, while transient and
  unknown errors keep the existing retry behavior.
- **Dedupe per-round error records in SessionLog** — identical (round, message) errors are recorded
  once instead of stacking one copy per attempt.
- **Native Windows shell semantics in the local code executor** — keep cmd.exe-required environment
  variables and stop wrapping compound commands in a usually-absent POSIX `sh` on Windows.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [ ] Documentation reflects the changes where applicable
