### PR TITLE
fix: apply generate script LLM overrides

### DIFF
--- a/projects/singularity_cinema/generate_script/agent.py
+++ b/projects/singularity_cinema/generate_script/agent.py
@@ -31,7 +31,7 @@ class GenerateScript(LLMAgent):
         config = deepcopy(self.config)
         config.generation_config.temperature = 0.6
         config.generation_config.top_k = 50
-        self.llm: LLM = LLM.from_config(self.config)
+        self.llm: LLM = LLM.from_config(config)
 
     def on_task_end(self, messages: List[Message]):
         script = os.path.join(self.work_dir, 'script.txt')


### PR DESCRIPTION
## Summary

Fixes an ineffective `GenerateScript.prepare_llm()` override: the method configured a copied config but passed the unmodified source config to `LLM.from_config`.

## Validation

- `python3 -m py_compile projects/singularity_cinema/generate_script/agent.py`
- Focused mocked smoke test confirming the copied config passes `temperature=0.6` and `top_k=50`, while the source config remains unchanged.

## Scope

One-line source fix; no dependency or behavior changes outside the singularity-cinema script-generation LLM setup.