### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,7 +631,7 @@ This project is licensed under the [Apache License (Version 2.0)](https://github
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=modelscope/modelscope-agent&type=Date)](https://star-history.com/#modelscope/modelscope-agent&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=modelscope/modelscope-agent&type=Date)](https://star-history.dera.page/#modelscope/modelscope-agent&Date)
 
 
 ---

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -627,4 +627,4 @@ ms-agent ui --no-browser
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=modelscope/modelscope-agent&type=Date)](https://star-history.com/#modelscope/modelscope-agent&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=modelscope/modelscope-agent&type=Date)](https://star-history.dera.page/#modelscope/modelscope-agent&Date)


### PR DESCRIPTION
The star history chart in README.md and README_ZH.md is currently broken: it no longer renders because the upstream API is affected by GitHub stargazer restrictions.

This change points the chart to a working alternative so the star history displays correctly again. It also restores the wrapping link to use the same chart URL.