### PR TITLE
feat: add OrcaRouter as a built-in OpenAI-compatible provider

### DIFF
--- a/ms_agent/llm/spec.py
+++ b/ms_agent/llm/spec.py
@@ -220,6 +220,16 @@ class ProviderRegistry:
                 keywords=[],
                 capabilities=openai_caps,
             ),
+            ProviderSpec(
+                name='orcarouter',
+                display_name='OrcaRouter',
+                transport=TRANSPORT_OPENAI_COMPAT,
+                api_key_env=['ORCAROUTER_API_KEY'],
+                default_base_url='https://api.orcarouter.ai/v1',
+                base_url_env=['ORCAROUTER_BASE_URL'],
+                keywords=[],
+                capabilities=openai_caps,
+            ),
         ]
         for spec in builtins:
             self.register(spec)

--- a/tests/llm/test_provider_layer.py
+++ b/tests/llm/test_provider_layer.py
@@ -18,7 +18,7 @@ from modelscope.utils.test_utils import test_level
 
 EXPECTED_PROVIDERS = {
     'openai', 'anthropic', 'google', 'modelscope', 'zhipu', 'deepseek',
-    'dashscope', 'minimax', 'openrouter', 'kimi'
+    'dashscope', 'minimax', 'openrouter', 'orcarouter', 'kimi'
 }
 
 
@@ -74,6 +74,14 @@ class TestProviderRegistry(unittest.TestCase):
         spec = get_registry().get('zhipu')
         self.assertIn('GLM_API_KEY', spec.api_key_env)
         self.assertIn('GLM_BASE_URL', spec.base_url_env)
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_orcarouter_uses_orca_env(self):
+        spec = get_registry().get('orcarouter')
+        self.assertIn('ORCAROUTER_API_KEY', spec.api_key_env)
+        self.assertIn('ORCAROUTER_BASE_URL', spec.base_url_env)
+        self.assertEqual('https://api.orcarouter.ai/v1', spec.default_base_url)
+        self.assertEqual('openai_compat', spec.transport)
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_continue_gen_modes(self):

--- a/tests/llm/test_provider_router_live.py
+++ b/tests/llm/test_provider_router_live.py
@@ -54,6 +54,7 @@ PROVIDERS = {
     'kimi': ('moonshot-v1-8k', 'KIMI_API_KEY'),
     'minimax': ('MiniMax-M2', 'MINIMAX_API_KEY'),
     'openrouter': ('qwen/qwen3.7-plus', 'OpenRouter_API_KEY'),
+    'orcarouter': ('orcarouter/auto', 'ORCAROUTER_API_KEY'),
 }
 
 
@@ -145,6 +146,10 @@ class TestProviderRouterLive(unittest.TestCase):
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_openrouter(self):
         self._run('openrouter')
+
+    @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
+    def test_orcarouter(self):
+        self._run('orcarouter')
 
     @unittest.skipUnless(test_level() >= 0, 'skip test in current test level')
     def test_reasoning_content(self):

--- a/webui/backend/.env.example
+++ b/webui/backend/.env.example
@@ -19,7 +19,7 @@ OPENAI_BASE_URL=
 
 # Which provider/model the chat runtime uses when settings.json has no llm block.
 # provider must be a known registry id: openai | modelscope | dashscope | zhipu |
-# kimi | deepseek | minimax | openrouter | anthropic | google
+# kimi | deepseek | minimax | openrouter | orcarouter | anthropic | google
 # Keep the pair coherent — the model must exist AT that provider. A mismatch is
 # not cosmetic: the model is registered under the provider and can shadow the
 # correct one in the picker. qwen* models are DashScope/ModelScope, not OpenAI.

--- a/webui/backend/tests/test_providers.py
+++ b/webui/backend/tests/test_providers.py
@@ -9,7 +9,7 @@ from ms_agent.llm.spec import get_registry
 
 _EXPECTED_BUILTINS = {
     "openai", "anthropic", "google", "modelscope", "zhipu",
-    "kimi", "deepseek", "dashscope", "minimax", "openrouter",
+    "kimi", "deepseek", "dashscope", "minimax", "openrouter", "orcarouter",
 }
 
 


### PR DESCRIPTION
Adds [OrcaRouter](https://www.orcarouter.ai) as a built-in OpenAI-compatible provider, mirroring how OpenRouter is wired into the data-driven provider layer.

OrcaRouter is an OpenAI-compatible gateway that reaches 100+ model providers through a single endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `ms_agent/llm/spec.py`: new `orcarouter` `ProviderSpec` (`openai_compat` transport, `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` env chain, default base `https://api.orcarouter.ai/v1`), mirroring the `openrouter` entry — one data-driven spec, no new class
- `tests/llm/test_provider_layer.py`: `orcarouter` added to `EXPECTED_PROVIDERS` + spec-shape test `test_orcarouter_uses_orca_env`
- `tests/llm/test_provider_router_live.py`: `orcarouter` in `PROVIDERS` (`orcarouter/auto`) + `test_orcarouter` live test (skips without `ORCAROUTER_API_KEY`, same pattern as OpenRouter)
- `webui/backend/tests/test_providers.py`: `orcarouter` added to `_EXPECTED_BUILTINS` (WebUI "fill an API key" catalog)
- `webui/backend/.env.example`: `orcarouter` listed among known registry ids

## Verification

- Registry check (isolated spec import): `orcarouter` resolves with the expected transport / env chain / default base URL; `list_providers()` includes it; case-insensitive lookup works
- Live probe against `https://api.orcarouter.ai/v1` with `orcarouter/auto`: non-stream completion and a tool call (`mkdir` → `{"dir_name":"demo"}`) both returned (auto-routed to `deepseek-v4-pro` / `MiniMax-M2.7` across probes)
- `py_compile` + `flake8` clean on changed files; formatting matches the adjacent `openrouter` entry

I'm an engineer on the OrcaRouter team.
