### PR TITLE
fix(agent_hub): route qoder persona into AGENTS.md instead of agents/…

### DIFF
--- a/ms_agent/agent_hub/_commands.py
+++ b/ms_agent/agent_hub/_commands.py
@@ -814,6 +814,8 @@ def _file_per_agent_identity_path(dst_spec: WorkspaceSpec) -> str | None:
     agent name so converted persona content can be routed into that file.
     Returns ``None`` when the layout has no single ``{name}`` file pattern.
     """
+    if dst_spec.product_name == 'qoder':
+        return None
     name = dst_spec.agent_name or DEFAULT_AGENT_NAME
     for pattern in dst_spec.patterns:
         # Only single-file placeholders (no wildcard) identify the persona file;


### PR DESCRIPTION
…{name}.md

<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

qoder injects persona from .qoder/AGENTS.md, but convert routed SOUL.md overflow into agents/{name}.md. Return None from _file_per_agent_identity_path for qoder so persona folds into the shared AGENTS.md.

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [ ] Documentation reflects the changes where applicable
