### PR TITLE
fix(agent_hub): hint manual openhuman agent registration after conver…

### DIFF
--- a/ms_agent/agent_hub/_commands.py
+++ b/ms_agent/agent_hub/_commands.py
@@ -30,6 +30,40 @@ logger = get_logger()
 # ---------------------------------------------------------------------------
 
 
+def _print_openhuman_next_steps(root) -> None:
+    """After a successful convert/download, remind the user that the result is
+    not yet usable: openhuman discovers agents only through the
+    ``workspace/agents/<id>.toml`` registry, which we deliberately do not
+    generate, so they must create it by hand.
+
+    Uses ``Logger.info`` rather than ``display``/``print`` per the tech lead's
+    requirement.
+    """
+    agents_dir = f'{root}/agents'
+    logger.info(
+        '转换/下载已完成，但当前还不能直接使用（若尚未注册）。OpenHuman 只通过 '
+        'workspace/agents/<agent-id>.toml 注册表发现智能体，本次仅写入了 persona/skill 文件。\n'
+        '请手动完成：\n'
+        f'  1) 在 {agents_dir}/ 下手动创建 <agent-id>.toml，包含 id / when_to_use / '
+        'system_prompt.inline（粘贴 SOUL.md 内容）/ model.exact="inherit"；id 仅限字母、数字、"_"、"-"。\n'
+        '  2) UI「设置 → 智能体 → 新建智能体」，id / model / 工具白名单与 TOML 保持一致。\n'
+        '  3) UI「设置 → 智能体配置 → 新建配置」，base agent id 填同一个 id。\n'
+        '  4) 新建一个对话即可使用。'
+    )
+    logger.info(
+        'Conversion/download finished, but the agent is NOT usable yet '
+        '(if you have not registered it). OpenHuman discovers agents only via the '
+        'workspace/agents/<agent-id>.toml registry; this run wrote persona/skill files only.\n'
+        'Manual steps:\n'
+        f'  1) Create {agents_dir}/<agent-id>.toml with: id / when_to_use / '
+        'system_prompt.inline (paste the SOUL.md content) / model.exact="inherit"; '
+        'id may contain only letters, digits, "_", "-".\n'
+        '  2) UI "Settings → Agents → New Agent": keep id / model / tool allowlist consistent with the TOML.\n'
+        '  3) UI "Settings → Agent Config → New Config": set base agent id to the same id.\n'
+        '  4) Start a new conversation.'
+    )
+
+
 def _fail(message: str) -> int:
     """Print an error and return exit code 1."""
     print(f'Error: {message}', file=sys.stderr)
@@ -796,6 +830,8 @@ def cmd_download(
 
     written = spec.apply(filtered)
     display.done(f'Wrote {len(written)} file(s) under {root}')
+    if target_fw == 'openhuman' and written:
+        _print_openhuman_next_steps(root)
 
     # Download is overwrite/add-only and never deletes local files. The remote
     # holds only the user's customized content (unchanged framework defaults are
@@ -1049,6 +1085,8 @@ def convert_workspace(
 
     written = dst_spec.apply(effective)
     display.done(f'Wrote {len(written)} file(s) under {dst_root}')
+    if target_fw == 'openhuman':
+        _print_openhuman_next_steps(dst_root)
     return 0
 
 

--- a/ms_agent/agent_hub/_commands.py
+++ b/ms_agent/agent_hub/_commands.py
@@ -40,10 +40,16 @@ def _print_openhuman_next_steps(root) -> None:
     requirement.
     """
     agents_dir = f'{root}/agents'
+    doc = ('https://github.com/tinyhumansai/openhuman/blob/main/'
+           'gitbooks/developing/architecture/agent-harness.md')
+    example = ('https://github.com/tinyhumansai/openhuman/blob/main/'
+               'src/openhuman/agent/registry/agents/researcher/agent.toml')
     logger.info(
         '转换/下载已完成，但当前还不能直接使用（若尚未注册）。OpenHuman 只通过 '
         'workspace/agents/<agent-id>.toml 注册表发现智能体，本次仅写入了 persona/skill 文件。\n'
         '请手动完成：\n'
+        '  官方文档（如何构建 agent.toml）：' + doc + '\n'
+        '  官方示例（researcher/agent.toml）：' + example + '\n'
         f'  1) 在 {agents_dir}/ 下手动创建 <agent-id>.toml，包含 id / when_to_use / '
         'system_prompt.inline（粘贴 SOUL.md 内容）/ model.exact="inherit"；id 仅限字母、数字、"_"、"-"。\n'
         '  2) UI「设置 → 智能体 → 新建智能体」，id / model / 工具白名单与 TOML 保持一致。\n'
@@ -55,6 +61,8 @@ def _print_openhuman_next_steps(root) -> None:
         '(if you have not registered it). OpenHuman discovers agents only via the '
         'workspace/agents/<agent-id>.toml registry; this run wrote persona/skill files only.\n'
         'Manual steps:\n'
+        '  Official docs (how to build agent.toml): ' + doc + '\n'
+        '  Official example (researcher/agent.toml): ' + example + '\n'
         f'  1) Create {agents_dir}/<agent-id>.toml with: id / when_to_use / '
         'system_prompt.inline (paste the SOUL.md content) / model.exact="inherit"; '
         'id may contain only letters, digits, "_", "-".\n'


### PR DESCRIPTION
…t/download

<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number
Convert/download to openhuman only writes persona/skill files, which the app cannot discover without a workspace/agents/<id>.toml registry. Print bilingual next-steps via logger.info after a successful convert/download to openhuman.

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [ ] Documentation reflects the changes where applicable
