### PR TITLE
fix(permission): resolve redirect targets against the cd-tracked cwd

### DIFF
--- a/ms_agent/permission/shell_validator.py
+++ b/ms_agent/permission/shell_validator.py
@@ -126,8 +126,12 @@ class ShellPathValidator:
             if not tokens:
                 continue
 
-            # 3. Check output redirections on the raw sub-command string
-            redirect_result = self._check_redirects(sub_cmd)
+            # 3. Check output redirections on the raw sub-command string.
+            # Resolve relative targets against the cd-tracked cwd, matching
+            # how the shell itself resolves them. Note this runs before the
+            # `cd` below updates _current_cwd, which is also what the shell
+            # does for a command like `cd foo > log`.
+            redirect_result = self._check_redirects(sub_cmd, cwd=_current_cwd)
             if redirect_result.action != 'allow':
                 return redirect_result
 
@@ -325,7 +329,11 @@ class ShellPathValidator:
         return SafetyDecision(
             action='allow', reason=f'{cmd_name}: all paths validated')
 
-    def _check_redirects(self, sub_cmd: str) -> SafetyDecision:
+    def _check_redirects(self,
+                         sub_cmd: str,
+                         *,
+                         cwd: str | None = None) -> SafetyDecision:
+        effective_cwd = cwd or self._workspace_root
         for match in _REDIRECT_PATTERN.finditer(sub_cmd):
             target = match.group(1)
             if _FD_REDIRECT.match(target):
@@ -341,7 +349,7 @@ class ShellPathValidator:
 
             result = validate_path(
                 target,
-                self._workspace_root,
+                effective_cwd,
                 self._allowed_dirs,
                 'create',
                 read_only_dirs=self._read_only_dirs,

--- a/tests/permission/test_shell_validator.py
+++ b/tests/permission/test_shell_validator.py
@@ -5,7 +5,8 @@ import tempfile
 
 import pytest
 
-from ms_agent.permission.shell_validator import ShellPathValidator
+from ms_agent.permission.shell_validator import (PathSafetyConfig,
+                                                 ShellPathValidator)
 
 
 @pytest.fixture
@@ -97,6 +98,60 @@ class TestRedirects:
     def test_redirect_with_variable(self, validator):
         r = validator.check('echo hello > $HOME/file')
         assert r.action == 'deny'
+
+
+class TestRedirectCwdTracking:
+    """Relative redirect targets must resolve against the cd-tracked cwd.
+
+    The shell resolves ``>`` targets against the current working directory,
+    so a compound command like ``cd sub && echo x > ../f`` writes to
+    ``<cwd>/sub/../f``. Validating the target against the workspace root
+    instead disagrees with what actually happens on disk in both directions.
+    """
+
+    @pytest.fixture
+    def layout(self, tmp_path):
+        work = tmp_path / 'a' / 'b' / 'work'
+        work2 = tmp_path / 'a' / 'b' / 'work2'
+        cache = tmp_path / 'cache'
+        for p in (work / 'sub', work2, cache):
+            p.mkdir(parents=True)
+        allowed = (str(work), str(work2), str(cache))
+        validator = ShellPathValidator(
+            allowed_dirs=list(allowed),
+            safety_config=PathSafetyConfig(
+                allowed_directories=allowed, workspace_root=str(work)),
+        )
+        return validator, work, work2, cache
+
+    def test_relative_redirect_after_cd_into_subdir(self, layout):
+        """``cd work/sub && echo x > ../f`` writes work/f — inside allowed."""
+        validator, work, _, _ = layout
+        r = validator.check(f'cd {work}/sub && echo x > ../f')
+        assert r.action == 'allow'
+
+    def test_relative_redirect_escaping_after_cd(self, layout):
+        """``cd cache && echo x > ../work2/f`` writes outside allowed dirs.
+
+        Resolved against the workspace root the target would look like
+        ``work/../work2/f`` (an allowed directory), but the shell writes to
+        ``cache/../work2/f``, which is not allowed.
+        """
+        validator, _, _, cache = layout
+        r = validator.check(f'cd {cache} && echo x > ../work2/f')
+        assert r.action != 'allow'
+
+    def test_redirect_without_cd_uses_workspace_root(self, layout):
+        validator, _, _, _ = layout
+        r = validator.check('echo x > f')
+        assert r.action == 'allow'
+
+    def test_redirect_matches_argument_path_validation(self, layout):
+        """Redirects and ordinary path arguments must agree on the cwd."""
+        validator, work, _, _ = layout
+        rm = validator.check(f'cd {work}/sub && rm ../f')
+        redirect = validator.check(f'cd {work}/sub && echo x > ../f')
+        assert rm.action == redirect.action == 'allow'
 
 
 class TestProcessSubstitution:


### PR DESCRIPTION
## Change Summary

`ShellPathValidator.check()` tracks `cd` as it walks a compound command and passes the
resulting cwd down to `_check_command()`. `_check_redirects()` never got that treatment —
it resolves relative redirect targets against `self._workspace_root` regardless of where
the shell has actually moved.

So two halves of the same check disagree with each other:

    cd work/sub && rm ../f        ->  allow   (correct)
    cd work/sub && echo x > ../f  ->  deny    (wrong — this writes work/f)

Both commands touch the same file. Only one of them is judged correctly.

The mismatch goes both ways. Writes that stay inside the workspace get rejected, which is
the harmless direction. The other direction: a relative target can resolve into an allowed
directory when measured from the workspace root while the shell writes somewhere else. I
could only reproduce that with several `allowed_dirs` at differing depths, and it also
needs the real parent directory to already exist, so I doubt it amounts to much in
practice. Wrong either way.

The fix hands the tracked cwd to `_check_redirects()`. The call stays where it is, ahead
of the `cd` bookkeeping, because a shell resolves the redirect in `cd foo > log` against
the old cwd as well.

## Related issue number

None.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [ ] Documentation reflects the changes where applicable

Added `TestRedirectCwdTracking` in `tests/permission/test_shell_validator.py` — four cases
covering both directions plus one asserting that redirects and ordinary path arguments
agree on the cwd. Reverting `shell_validator.py` and keeping the tests fails three of them.

`tests/permission/` is at 340 passed. Note that a plain `pytest tests/permission/` gave me
30 failures on async tests before I touched anything; they need `pytest-asyncio` and pass
with `--asyncio-mode=auto`. Unrelated to this change, but it tripped me up while
establishing a baseline, so flagging it in case the CI config is worth a look.

Docs box left unchecked — the behaviour matches what the docstrings already describe, so
there was nothing to update.