### PR TITLE
fix: report the end of reasoning when the model starts calling

### DIFF
--- a/ms_agent/agent/llm_agent.py
+++ b/ms_agent/agent/llm_agent.py
@@ -1187,6 +1187,18 @@ class LLMAgent(Agent):
     #: second, large enough that a short call emits once and stops.
     _COMPOSING_STEP = 256
 
+    @staticmethod
+    def _is_writing_tool_call(message) -> bool:
+        """Whether this streamed message has begun a tool call. The name arrives
+        before the arguments, so a NAMED call is the first sign the response
+        moved from thinking to calling (same test ``_emit_tool_composing`` uses).
+        """
+        for call in getattr(message, 'tool_calls', None) or []:
+            if isinstance(call, dict) and (call.get('tool_name')
+                                           or call.get('name')):
+                return True
+        return False
+
     def _emit_tool_composing(self, message, announced: Dict[int, int]) -> None:
         """Report tool calls the model is still writing.
 
@@ -2145,6 +2157,16 @@ class LLMAgent(Agent):
                                 _printed_reasoning_footer = True
                             self._emit_content(new_content)
                         _content = _response_message.content
+                        # Thinking ends when the model starts writing a tool call,
+                        # not when the response drains — for a call carrying a
+                        # whole file those are a minute apart, and both the UI
+                        # timer and the persisted `reasoning_duration` read this
+                        # boundary. Mirrors the content branch above.
+                        if (_printed_reasoning_header
+                                and not _printed_reasoning_footer
+                                and self._is_writing_tool_call(_response_message)):
+                            self._emit_reasoning_end()
+                            _printed_reasoning_footer = True
                         self._emit_tool_composing(_response_message, _composing)
                         if not _reported_images:
                             # After the first chunk, not before it: the payload's

--- a/tests/ui/test_agent_seam.py
+++ b/tests/ui/test_agent_seam.py
@@ -60,3 +60,24 @@ def test_no_sink_reasoning_goes_to_stdout(capsys):
     a._emit_reasoning_end()
     out = capsys.readouterr().out
     assert 'thinking' in out and 'mulling' in out
+
+
+# ── where thinking ends ───────────────────────────────────────────────────
+# Both the UI timer and the persisted `reasoning_duration` are measured to this
+# boundary, so it has to be "the model started calling", not "the stream ended".
+
+
+class _Msg:
+    def __init__(self, tool_calls=None):
+        self.tool_calls = tool_calls
+
+
+def test_named_tool_call_marks_the_end_of_thinking():
+    started = LLMAgent._is_writing_tool_call
+    assert started(_Msg()) is False
+    assert started(_Msg([])) is False
+    # Arguments without a name yet: not the boundary (nor what composing waits for).
+    assert started(_Msg([{'arguments': '{"path": "a.md"'}])) is False
+    assert started(_Msg([{'tool_name': 'file_system---write_file'}])) is True
+    assert started(_Msg([{'name': 'write_file', 'arguments': ''}])) is True
+    assert started(_Msg(['nonsense'])) is False  # never raise mid-stream


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

- Problem: ReasoningEnded fired only on the first content token or when the stream drained. Reasoning-to-tool rounds have no content token, so it waited for all tool arguments—up to a minute for a whole file.
- Fix：Close the reasoning block at the first named tool call. The name arrives before its arguments and uses the same boundary check as _emit_tool_composing, consistent with the existing content path.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [ ] Documentation reflects the changes where applicable
