### PR TITLE
reject unrecognized args in agent CLI

### DIFF
--- a/ms_agent/cli/cli.py
+++ b/ms_agent/cli/cli.py
@@ -38,12 +38,21 @@ def run_cmd():
     PluginCMD.define_args(subparsers)
 
     # unknown args will be handled in config.py
-    args, _ = parser.parse_known_args()
+    args, unknown = parser.parse_known_args()
 
     if not hasattr(args, 'func'):
         parser.print_help()
         exit(1)
     cmd = args.func(args)
+    # ``agent`` subcommands take no positional args and never consume the
+    # ad-hoc ``--key value`` overrides that Config.parse_args extracts, so a
+    # leftover argument is always a user mistake (e.g. a bare path that would
+    # silently fall back to the framework default workspace on upload).
+    if unknown and isinstance(cmd, AgentCMD):
+        parser.error(
+            f'unrecognized arguments: {" ".join(unknown)} '
+            '(`ms-agent agent` takes no positional arguments; '
+            'use --local-dir to specify a local directory)')
     cmd.execute()
 
 

--- a/tests/cli/test_cli_entry.py
+++ b/tests/cli/test_cli_entry.py
@@ -1,0 +1,78 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Entry-point tests: unknown arguments are rejected for `agent` subcommands.
+
+Regression test for the bug where `ms-agent agent upload <dir> ...` silently
+dropped the positional path (parse_known_args) and uploaded the framework
+default workspace (~/.ms_agent) instead.
+"""
+import sys
+
+import pytest
+
+from ms_agent.cli.agent import AgentCMD
+from ms_agent.cli.cli import run_cmd
+
+
+def test_agent_upload_positional_path_is_rejected(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys, 'argv', [
+            'ms-agent', 'agent', 'upload', '/tmp/leak_demo', '-f', 'ms-agent',
+            '-r', 'user/test-leak'
+        ])
+
+    def _fail_execute(self):
+        raise AssertionError('execute() must not run for rejected arguments')
+
+    monkeypatch.setattr(AgentCMD, 'execute', _fail_execute)
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_cmd()
+    assert exc_info.value.code == 2
+    stderr = capsys.readouterr().err
+    assert 'unrecognized arguments: /tmp/leak_demo' in stderr
+    assert '--local-dir' in stderr
+
+
+def test_agent_unknown_option_is_rejected(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys, 'argv',
+        ['ms-agent', 'agent', 'upload', '-f', 'ms-agent', '-r', 'user/x',
+         '--dry-runn'])
+
+    def _fail_execute(self):
+        raise AssertionError('execute() must not run for rejected arguments')
+
+    monkeypatch.setattr(AgentCMD, 'execute', _fail_execute)
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_cmd()
+    assert exc_info.value.code == 2
+    assert 'unrecognized arguments: --dry-runn' in capsys.readouterr().err
+
+
+def test_valid_agent_command_still_dispatches(monkeypatch):
+    monkeypatch.setattr(
+        sys, 'argv', ['ms-agent', 'agent', 'status', '-f', 'ms-agent'])
+
+    dispatched = {}
+    monkeypatch.setattr(
+        AgentCMD, 'execute', lambda self: dispatched.setdefault('ok', True))
+
+    run_cmd()
+    assert dispatched.get('ok')
+
+
+def test_non_agent_command_keeps_unknown_args(monkeypatch):
+    # `run` consumes ad-hoc `--key value` overrides via Config.parse_args,
+    # so unknown arguments must keep passing through for non-agent commands.
+    from ms_agent.cli.run import RunCMD
+    monkeypatch.setattr(
+        sys, 'argv',
+        ['ms-agent', 'run', '--config', 'cfg', '--temperature', '0.5'])
+
+    dispatched = {}
+    monkeypatch.setattr(
+        RunCMD, 'execute', lambda self: dispatched.setdefault('ok', True))
+
+    run_cmd()
+    assert dispatched.get('ok')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

<!-- Please give a short summary of the changes. -->

`ms-agent agent upload <dir> ...` silently dropped the positional path
(parse_known_args) and fell back to the framework default workspace
(~/.ms_agent), pushing the user's real profile to the remote repo.
 
Unknown arguments are now rejected for `agent` subcommands before
dispatch. Other commands keep lenient parsing so ad-hoc `--key value`
config overrides (Config.parse_args) are unaffected.

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [ ] Documentation reflects the changes where applicable
