### PR TITLE
fix(webui): restore tool defaults after config updates

### DIFF
--- a/ms_agent/config/resolver.py
+++ b/ms_agent/config/resolver.py
@@ -8,6 +8,9 @@ Merges config from five layers (later wins):
   4. Project patch        (<project>/.ms-agent/config.yaml)
   5. Session overrides    (runtime overrides, e.g. model switch in a session)
 
+Callers may supply interface ``defaults`` between layers 1 and 2. These apply
+only to that resolver, so a WebUI profile does not change ordinary SDK agents.
+
 MCP/Skills merge semantics:
   - Union by name, project-level overrides global on conflict
   - Each entry carries an `enabled` flag
@@ -77,11 +80,14 @@ class ConfigResolver:
         project_root: Union[str, Path, None] = None,
         agent_config: DictConfig | ListConfig | None = None,
         mcp_manager: MCPConfigManager | None = None,
+        defaults: Optional[Dict[str, Any]] = None,
     ) -> None:
         self._global_dir = Path(global_dir).expanduser()
         self.project_root = (
             Path(project_root).expanduser() if project_root else None)
         self.agent_config = agent_config
+        # Interface defaults sit above framework defaults, below all user layers.
+        self.defaults = deepcopy(defaults)
         self.mcp_manager = mcp_manager or MCPConfigManager(
             self._global_dir, self.project_root)
         self.plugin_manager = PluginConfigManager(self._global_dir,
@@ -113,6 +119,8 @@ class ConfigResolver:
         layers: List[DictConfig] = []
 
         layers.append(self._load_framework_defaults())
+        if self.defaults is not None:
+            layers.append(OmegaConf.create(self.defaults))
 
         global_settings = self._load_global_settings()
         if global_settings:
@@ -137,7 +145,10 @@ class ConfigResolver:
         if session_overrides:
             layers.append(OmegaConf.create(session_overrides))
 
-        merged = self._merge_layers(layers)
+        merged = self._merge_layers(layers, merge_tools=self.defaults is not None)
+        for name in collect_builtin_tool_names(OmegaConf.create(self.defaults or {})):
+            if OmegaConf.select(merged, f'tools.{name}.mcp') is not False:
+                raise ValueError(f'tools.{name} is a built-in tool; mcp must be false')
 
         merged = self._merge_mcp(merged, effective_project_path)
         merged = self._merge_skills(merged, effective_project_path)
@@ -290,17 +301,27 @@ class ConfigResolver:
 
         if not layers:
             return None
-        return self._merge_layers(layers)
+        return self._merge_layers(layers, merge_tools=self.defaults is not None)
 
     # -- merging --
 
     @staticmethod
-    def _merge_layers(layers: List[DictConfig]) -> DictConfig:
+    def _merge_layers(layers: List[DictConfig], *, merge_tools: bool = False) -> DictConfig:
         if not layers:
             return OmegaConf.create({})
         result = layers[0]
         for layer in layers[1:]:
+            tools = None
+            if merge_tools and 'tools' in layer:
+                from ms_agent.config.tool_settings import merge_tool_settings
+                tools = merge_tool_settings(
+                    OmegaConf.to_container(result.tools)
+                    if OmegaConf.is_config(result.get('tools')) else {},
+                    OmegaConf.to_container(layer.tools)
+                    if OmegaConf.is_config(layer.tools) else layer.tools)
             result = OmegaConf.merge(result, layer)
+            if tools is not None:
+                OmegaConf.update(result, 'tools', tools, merge=False)
         return result
 
     def _merge_mcp(self, config: DictConfig,

--- a/ms_agent/config/tool_settings.py
+++ b/ms_agent/config/tool_settings.py
@@ -1,0 +1,56 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Merge tool settings without losing switches or mixing include/exclude lists."""
+from copy import deepcopy
+
+from ms_agent.utils.constants import TOOL_PLUGIN_NAME
+
+
+def merge_tool_settings(base: dict, patch: dict) -> dict:
+    """Missing fields inherit; explicit values (including lists) replace.
+
+    ``null`` is not a disable operation. Use ``enabled: false`` so a partial
+    config cannot accidentally erase a tool's type or execution settings.
+    """
+    if not isinstance(base, dict) or not isinstance(patch, dict):
+        raise ValueError('tools must be an object; use enabled: false to disable a tool')
+    result = deepcopy(base)
+    for name, values in patch.items():
+        if name == TOOL_PLUGIN_NAME:
+            result[name] = deepcopy(values)
+            continue
+        if not isinstance(values, dict):
+            raise ValueError(
+                f'tools.{name} must be an object; use enabled: false to disable it')
+        for flag in ('enabled', 'mcp'):
+            if flag in values and not isinstance(values[flag], bool):
+                raise ValueError(f'tools.{name}.{flag} must be a boolean')
+        for selector in ('include', 'exclude'):
+            if selector in values and (
+                    not isinstance(values[selector], list)
+                    or any(not isinstance(item, str) for item in values[selector])):
+                raise ValueError(f'tools.{name}.{selector} must be a list of names')
+        if values.get('include') and values.get('exclude'):
+            raise ValueError(f'tools.{name}: set either include or exclude, not both')
+        previous = result.get(name) or {}
+        if not isinstance(previous, dict):
+            raise ValueError(f'tools.{name} must be an object')
+        if previous.get('mcp') is False and values.get('mcp') is True:
+            raise ValueError(f'tools.{name} is a built-in tool; mcp must be false')
+        merged = _merge_mapping(previous, values)
+        # Selecting one mode replaces the inherited mode, even for an empty list.
+        if 'include' in values and 'exclude' not in values:
+            merged.pop('exclude', None)
+        if 'exclude' in values and 'include' not in values:
+            merged.pop('include', None)
+        result[name] = merged
+    return result
+
+
+def _merge_mapping(base: dict, patch: dict) -> dict:
+    result = deepcopy(base)
+    for key, value in patch.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _merge_mapping(result[key], value)
+        else:
+            result[key] = deepcopy(value)
+    return result

--- a/ms_agent/tools/tool_manager.py
+++ b/ms_agent/tools/tool_manager.py
@@ -196,7 +196,7 @@ class ToolManager:
             self.extra_tools.append(
                 FileSystemTool(
                     config, trust_remote_code=self.trust_remote_code))
-        if hasattr(config, 'tools') and hasattr(config.tools, 'code_executor'):
+        if _tool_on(config, 'code_executor'):
             code_exec_cfg = getattr(config.tools, 'code_executor')
             implementation = getattr(code_exec_cfg, 'implementation',
                                      'sandbox')

--- a/tests/config/test_tool_settings.py
+++ b/tests/config/test_tool_settings.py
@@ -1,0 +1,81 @@
+import asyncio
+import json
+
+import pytest
+from omegaconf import OmegaConf
+
+from ms_agent.config.resolver import ConfigResolver
+from ms_agent.config.tool_settings import merge_tool_settings
+from ms_agent.tools.tool_manager import ToolManager
+
+
+def test_interface_defaults_are_below_user_layers(tmp_path):
+    defaults = {'tools': {
+        'todo_list': {'mcp': False},
+        'code_executor': {'mcp': False, 'implementation': 'python_env',
+                          'include': ['shell_executor']},
+    }}
+    original = json.dumps(defaults)
+    (tmp_path / 'settings.json').write_text(json.dumps({'tools': {
+        'code_executor': {'enabled': False},
+        'todo_list': {'auto_render_md': False},
+    }}))
+    project = tmp_path / 'project'
+    (project / '.ms_agent').mkdir(parents=True)
+    (project / '.ms_agent' / 'config.yaml').write_text(
+        'tools:\n  code_executor:\n    exclude: [shell_executor]\n')
+    cfg = ConfigResolver(global_dir=tmp_path, defaults=defaults).resolve(
+        project_path=str(project),
+        session_overrides={'tools': {'todo_list': {'plan_filename': 'session.json'}}})
+    assert cfg.tools.todo_list.mcp is False
+    assert cfg.tools.todo_list.auto_render_md is False
+    assert cfg.tools.todo_list.plan_filename == 'session.json'
+    assert cfg.tools.code_executor.enabled is False
+    assert 'include' not in cfg.tools.code_executor
+    assert list(cfg.tools.code_executor.exclude) == ['shell_executor']
+    assert json.dumps(defaults) == original
+    # An interface's defaults never leak into a normal SDK resolver.
+    plain = ConfigResolver(global_dir=tmp_path / 'other').resolve()
+    assert 'todo_list' not in plain.tools
+    assert 'python_executor' in plain.tools.code_executor.include
+
+
+@pytest.mark.parametrize('patch', [None, [], {'todo_list': None},
+                                 {'todo_list': False}, {'todo_list': {'mcp': 'false'}},
+                                 {'todo_list': {'enabled': 'false'}},
+                                 {'file_system': {'include': 'read_file'}},
+                                 {'file_system': {'include': ['a'], 'exclude': ['b']}}])
+def test_invalid_tool_config_has_actionable_error(patch):
+    with pytest.raises(ValueError, match='tools'):
+        merge_tool_settings({}, patch)
+
+
+@pytest.mark.parametrize('selection,removed', [('include', 'exclude'), ('exclude', 'include')])
+def test_selection_replaces_inherited_mode_even_if_empty(selection, removed):
+    base = {'file_system': {'mcp': False, removed: ['write_file'], 'enabled': False}}
+    merged = merge_tool_settings(base, {'file_system': {selection: []}})
+    assert removed not in merged['file_system']
+    assert merged['file_system'][selection] == []
+    assert merged['file_system']['enabled'] is False
+    assert removed in base['file_system']
+
+
+def test_partial_config_cannot_change_builtin_tool_to_mcp():
+    with pytest.raises(ValueError, match='built-in tool'):
+        merge_tool_settings({'todo_list': {'mcp': False}}, {'todo_list': {'mcp': True}})
+
+
+def test_disabled_code_executor_does_not_register_or_connect(tmp_path):
+    async def check():
+        manager = ToolManager(OmegaConf.create({
+            'output_dir': str(tmp_path),
+            'tools': {'code_executor': {'mcp': False, 'enabled': False,
+                                        'implementation': 'python_env'}},
+        }))
+        try:
+            await manager.connect()
+            assert not manager.extra_tools
+            assert not await manager.get_tools()
+        finally:
+            await manager.cleanup()
+    asyncio.run(check())

--- a/webui/backend/app/backends/ms_agent/bootstrap.py
+++ b/webui/backend/app/backends/ms_agent/bootstrap.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 
 from app.core.settings import settings
+from app.backends.ms_agent.defaults import DEFAULT_TOOLS as _DEFAULT_TOOLS
 
 
 _PROVIDER_BRAND_NAME_MIGRATIONS = {
@@ -32,8 +33,8 @@ def bootstrap() -> None:
     _export_env()
     pm()  # ProjectManager.__init__ ensures ~/.ms_agent/projects + default project
     _ensure_prompt_files(home())
-    _seed_llm_settings(home())
     _seed_tools_settings(home())
+    _seed_llm_settings(home())
     _migrate_provider_brand_names(home())
     # Normalize the model link so the chat dropdown lists the active model and
     # default_model is a full "provider/model" (see model_link).
@@ -214,81 +215,9 @@ def _seed_llm_settings(home_dir: str) -> None:
     os.replace(tmp, path)
 
 
-# Builtin repo tools seeded into settings.json so they are default-enabled and
-# toggleable through the standard multi-level config resolve (framework yaml ->
-# settings.json -> project yaml -> session). Presence of a `tools.<id>` key
-# enables it; add `enabled: false` to disable (honored by the SDK ToolManager).
-_DEFAULT_TOOLS: dict = {
-    "file_system": {
-        "mcp": False,
-        "include": ["read_file", "grep", "glob", "edit_file", "write_file"],
-    },
-    "todo_list": {"mcp": False},
-    # Shell/terminal only. implementation must be the SDK's "python_env" (a
-    # local Jupyter kernel, no Docker); "local"/"sandbox" route to the Docker
-    # CodeExecutionTool (needs ms-enclave). `include: [shell_executor]` exposes
-    # ONLY the terminal tool (not notebook/python/file_operation). Restricted
-    # permission gates shell_executor (not whitelisted) so every command asks.
-    "code_executor": {
-        "mcp": False,
-        "implementation": "python_env",
-        "include": ["shell_executor"],
-    },
-    # Web search is ON by default, and Tavily is the default engine because it
-    # is the only web-wide one that WORKS with no credentials: the SDK falls
-    # back to Tavily's keyless tier (tavily/search.py KEYLESS_HEADER) when no
-    # key is configured, so a fresh install can search immediately instead of
-    # silently having no engine until someone visits Settings -> Search. The
-    # keyless quota is a small sliding hourly bucket; adding a key lifts it, and
-    # a configured key always takes precedence.
-    "web_search": {"mcp": False, "engine": "tavily", "enabled": True},
-}
-
-# task_control has no WebUI rendering component yet; strip it from any home that
-# was seeded with the earlier default so it isn't loaded (idempotent migration).
-_DROP_TOOLS = ("task_control",)
-
 
 def _seed_tools_settings(home_dir: str) -> None:
-    """Write the default builtin-tool config into settings.json when absent, so
-    the tools are on out of the box and users can flip `enabled` per tool. Also
-    prunes retired defaults (``_DROP_TOOLS``) from an existing config."""
-    path = Path(home_dir) / "settings.json"
-    data: dict = {}
-    if path.exists():
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            data = {}
-    changed = False
-    if "tools" not in data:
-        data["tools"] = dict(_DEFAULT_TOOLS)
-        changed = True
-    else:
-        tools = data["tools"]
-        # Migration: drop retired default tools (only when present) so an
-        # already-seeded home stops loading a component the UI can't render.
-        for name in _DROP_TOOLS:
-            if name in tools:
-                del tools[name]
-                changed = True
-        # Add newly-introduced default tools that this home predates (e.g.
-        # code_executor), without overwriting a user's existing tool configs.
-        for name, cfg in _DEFAULT_TOOLS.items():
-            if name not in tools:
-                tools[name] = cfg
-                changed = True
-        # Enforce "terminal = shell only": a code_executor without an explicit
-        # include/exclude (i.e. still the un-customized default) is narrowed to
-        # shell_executor. A user's own include/exclude is left untouched.
-        ce = tools.get("code_executor")
-        if isinstance(ce, dict) and "include" not in ce and "exclude" not in ce:
-            ce["include"] = ["shell_executor"]
-            changed = True
-    if not changed:
-        return
+    """Persist the same defaults used after an external settings replacement."""
+    from app.backends.ms_agent.tool_settings import ensure_tool_settings
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
-    os.replace(tmp, path)
+    ensure_tool_settings(home_dir)

--- a/webui/backend/app/backends/ms_agent/config.py
+++ b/webui/backend/app/backends/ms_agent/config.py
@@ -1,7 +1,7 @@
 """Assemble the per-session run config and construct the LLMAgent (Route A).
 
-Mirrors ms_agent/tui/app.py: ConfigResolver.resolve() for the layered config
-(framework defaults -> settings.json -> project patch -> session overrides),
+Uses the SDK ConfigResolver.resolve() for the layered config
+(framework -> WebUI defaults -> settings.json -> project -> session),
 then route-A shaping (interactive lifecycle, streaming, session-log dir), then
 the managed MCP/skills bridge, then LLMAgent with the UI seams injected.
 """
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from app.backends.ms_agent.common import home
+from app.backends.ms_agent.defaults import DEFAULT_TOOLS, RETIRED_TOOLS
 
 logger = logging.getLogger("app.ms_agent.config")
 
@@ -51,8 +52,9 @@ def _apply_webui_defaults(config):
     }.items():
         if OmegaConf.select(config, key, default=None) is None:
             OmegaConf.update(config, key, value, merge=True)
-    # Builtin repo tools live in settings.json's `tools` block and are merged by
-    # the SDK ConfigResolver (multi-level resolve); nothing to inject here.
+    # Retired WebUI tools must not reappear after an import performed at runtime.
+    for name in RETIRED_TOOLS:
+        config.tools.pop(name, None)
     return config
 
 
@@ -984,8 +986,12 @@ def build_agent(project, session, *, event_sink, input_source, mcp_config=None,
     )
     from omegaconf import OmegaConf
 
+    from app.backends.ms_agent.tool_settings import ensure_tool_settings
+
     h = home()
-    resolver = ConfigResolver(global_dir=h, project_root=project.path)
+    ensure_tool_settings(h)
+    resolver = ConfigResolver(
+        global_dir=h, project_root=project.path, defaults={"tools": DEFAULT_TOOLS})
     sdir = session_dir(project, session)
     session_overrides = {
         # ① align the runtime SessionLog with the SessionManager session dir
@@ -1002,6 +1008,9 @@ def build_agent(project, session, *, event_sink, input_source, mcp_config=None,
         # other's plans). read_plan() resolves the same path.
         "tools": {
             "todo_list": {
+                # This is the built-in session plan, even when an existing
+                # settings block omits its MCP discriminator.
+                "mcp": False,
                 "plan_filename": os.path.join(sdir, "plan.json"),
                 "plan_md_filename": os.path.join(sdir, "plan.md"),
             },

--- a/webui/backend/app/backends/ms_agent/defaults.py
+++ b/webui/backend/app/backends/ms_agent/defaults.py
@@ -1,0 +1,35 @@
+"""Default tool scope for WebUI sessions."""
+
+# WebUI persists missing defaults at startup and before reading settings or
+# starting a turn. The same defaults remain below user settings at runtime.
+DEFAULT_TOOLS: dict = {
+    "file_system": {
+        "enabled": True,
+        "mcp": False,
+        "include": ["read_file", "grep", "glob", "edit_file", "write_file"],
+    },
+    "todo_list": {"enabled": True, "mcp": False},
+    # Shell/terminal only. implementation must be the SDK's "python_env" (a
+    # local Jupyter kernel, no Docker); "local"/"sandbox" route to the Docker
+    # CodeExecutionTool (needs ms-enclave). `include: [shell_executor]` exposes
+    # ONLY the terminal tool (not notebook/python/file_operation). Restricted
+    # permission gates shell_executor (not whitelisted) so every command asks.
+    "code_executor": {
+        "enabled": True,
+        "mcp": False,
+        "implementation": "python_env",
+        "include": ["shell_executor"],
+    },
+    # Web search is ON by default, and Tavily is the default engine because it
+    # is the only web-wide one that WORKS with no credentials: the SDK falls
+    # back to Tavily's keyless tier (tavily/search.py KEYLESS_HEADER) when no
+    # key is configured, so a fresh install can search immediately instead of
+    # silently having no engine until someone visits Settings -> Search. The
+    # keyless quota is a small sliding hourly bucket; adding a key lifts it, and
+    # a configured key always takes precedence.
+    "web_search": {"mcp": False, "engine": "tavily", "enabled": True},
+}
+
+# task_control has no WebUI rendering component yet; strip it from any home that
+# was seeded with the earlier default so it isn't loaded (idempotent migration).
+RETIRED_TOOLS = ("task_control",)

--- a/webui/backend/app/backends/ms_agent/model_link.py
+++ b/webui/backend/app/backends/ms_agent/model_link.py
@@ -25,13 +25,9 @@ def _path() -> Path:
 
 
 def _load_unlocked() -> dict:
-    p = _path()
-    if not p.exists():
-        return {}
-    try:
-        return json.loads(p.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return {}
+    from app.backends.ms_agent.tool_settings import ensure_tool_settings
+
+    return ensure_tool_settings(home())
 
 
 def _load() -> dict:

--- a/webui/backend/app/backends/ms_agent/runtime.py
+++ b/webui/backend/app/backends/ms_agent/runtime.py
@@ -198,6 +198,30 @@ def _mcp_fingerprint(project) -> str:
         return ""
 
 
+def _settings_fingerprint(project) -> str:
+    """Detect imports and file edits before reusing a session's frozen config."""
+    import hashlib
+    from pathlib import Path
+
+    from app.backends.ms_agent.common import home
+    from ms_agent.config.resolver import _project_internal_file
+
+    paths = [Path(home()) / "settings.json"]
+    paths.extend(_project_internal_file(project.path, name)
+                 for name in ("config.yaml", "settings.local.json"))
+    paths.extend(root / name for root in (Path(home()), Path(project.path))
+                 for name in ("AGENTS.md", "SOUL.md", "PROFILE.md"))
+    digest = hashlib.sha256()
+    for path in paths:
+        try:
+            content = path.read_bytes()
+        except (FileNotFoundError, NotADirectoryError):
+            content = b""
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+    return digest.hexdigest()
+
+
 def _ask_timeout_for(permission_mode: str | None) -> float | None:
     """``None`` — wait indefinitely — whenever the user chose to be asked.
 
@@ -307,6 +331,7 @@ class SessionRuntime:
         # Config identity at build time; get() compares it per turn so edits
         # made outside the management routes still reach the next turn.
         self.mcp_fingerprint = _mcp_fingerprint(project)
+        self.settings_fingerprint = _settings_fingerprint(project)
         # Set when this agent's configuration was superseded while it was
         # mid-turn (a memory-model edit, a store rebuild): it finishes the turn
         # it is in, and the NEXT one gets a freshly built agent. Without it a
@@ -544,11 +569,17 @@ class RuntimeRegistry:
         exited (e.g. after an error) or the active model changed (in-conversation
         model switch) so a fresh agent restores from SessionLog with the new model."""
         from app.backends.ms_agent import model_link
+        from app.backends.ms_agent.common import home
+        from app.backends.ms_agent.tool_settings import ensure_tool_settings
 
         async with self._create_lock:
             self._loop = asyncio.get_running_loop()  # for cross-thread toggles
             self._ensure_sweeper()
             rt = self._runtimes.get(session.id)
+            # External import services write the file directly. Complete its
+            # global defaults before fingerprinting so this write does not
+            # cause another rebuild on the following turn.
+            ensure_tool_settings(home())
             # Rebuild on a model switch or a superseded config, but never
             # mid-turn: an in-flight turn holds turn_lock, so defer the swap to
             # the next idle turn to avoid cancelling it. The MCP fingerprint
@@ -557,11 +588,13 @@ class RuntimeRegistry:
             # one — which previously took effect only for NEW sessions: the
             # session where the fix happened kept its frozen tool set.
             current_fp = _mcp_fingerprint(project)
+            current_settings = _settings_fingerprint(project)
             superseded = (
                 rt is not None
                 and not rt.turn_lock.locked()
                 and (rt.model_key != model_link.active_model()
                      or rt.needs_rebuild
+                     or rt.settings_fingerprint != current_settings
                      # Both sides non-empty: a fingerprint FAILURE ("") must
                      # neither force nor mask a rebuild.
                      or bool(current_fp and rt.mcp_fingerprint

--- a/webui/backend/app/backends/ms_agent/search.py
+++ b/webui/backend/app/backends/ms_agent/search.py
@@ -104,14 +104,9 @@ def _settings_path() -> Path:
 
 
 def _load() -> dict:
-    path = _settings_path()
-    if not path.exists():
-        return {}
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return {}
-    return data if isinstance(data, dict) else {}
+    from app.backends.ms_agent.tool_settings import ensure_tool_settings
+
+    return ensure_tool_settings(home())
 
 
 def _save(data: dict) -> None:

--- a/webui/backend/app/backends/ms_agent/tool_settings.py
+++ b/webui/backend/app/backends/ms_agent/tool_settings.py
@@ -1,0 +1,74 @@
+"""Keep persisted WebUI tool defaults complete after external config writes."""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from ms_agent.config.tool_settings import merge_tool_settings
+
+from app.backends.errors import BadRequest, Conflict
+from app.backends.ms_agent.defaults import DEFAULT_TOOLS, RETIRED_TOOLS
+from app.backends.ms_agent.settings_store import settings_lock
+
+
+def normalize_tool_settings(data: dict) -> dict:
+    """Fill missing defaults; preserve explicit switches and tool selections.
+
+    Only global tool settings belong here. Project overrides, session paths,
+    model credentials and template merging are handled by their own callers.
+    """
+    if not isinstance(data, dict):
+        raise ValueError("settings.json must contain an object")
+    tools = merge_tool_settings(DEFAULT_TOOLS, data.get("tools", {}))
+    for name in RETIRED_TOOLS:
+        tools.pop(name, None)
+    return {**data, "tools": tools}
+
+
+def _read(path: Path) -> bytes | None:
+    try:
+        return path.read_bytes()
+    except FileNotFoundError:
+        return None
+
+
+def ensure_tool_settings(home_dir: str | Path) -> dict:
+    """Read current settings, validate and atomically save missing tool fields.
+
+    External import services can replace settings.json without calling the SDK.
+    Never reuse a cached pre-import configuration or restore deleted credentials.
+    Recheck the source before replacement to avoid overwriting an observed
+    concurrent edit; external writers should also use atomic file replacement.
+    """
+    path = Path(home_dir) / "settings.json"
+    with settings_lock():
+        for _ in range(3):
+            before = _read(path)
+            try:
+                data = json.loads(before) if before is not None else {}
+                normalized = normalize_tool_settings(data)
+            except (UnicodeDecodeError, ValueError) as exc:
+                # The message names fields, never raw file contents or keys.
+                detail = ("settings.json must contain valid JSON"
+                          if isinstance(exc, (UnicodeDecodeError, json.JSONDecodeError))
+                          else str(exc))
+                raise BadRequest(f"Invalid WebUI settings: {detail}") from exc
+            if normalized == data:
+                return data
+
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fd, temporary = tempfile.mkstemp(prefix=".settings-", dir=path.parent)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as stream:
+                    json.dump(normalized, stream, ensure_ascii=False, indent=2)
+                    stream.write("\n")
+                if _read(path) != before:
+                    continue
+                os.replace(temporary, path)
+                return normalized
+            finally:
+                if os.path.exists(temporary):
+                    os.unlink(temporary)
+    raise Conflict("settings.json changed during normalization; please retry.")

--- a/webui/backend/tests/test_model_link.py
+++ b/webui/backend/tests/test_model_link.py
@@ -930,7 +930,7 @@ def test_seed_tools_settings_writes_default_block(tmp_path):
     assert tools["todo_list"]["mcp"] is False
     assert tools["code_executor"]["implementation"] == "python_env"
     assert tools["code_executor"]["include"] == ["shell_executor"]  # terminal only
-    assert tools["web_search"]["enabled"] is True
+    assert all(tool["enabled"] is True for tool in tools.values())
     # Tavily, not exa: the seeded engine must be one that works with no
     # credentials (keyless tier), so a fresh install can search immediately.
     assert tools["web_search"]["engine"] == "tavily"
@@ -945,7 +945,7 @@ def test_seed_tools_settings_writes_default_block(tmp_path):
     bootstrap._seed_tools_settings(str(tmp_path))
     migrated = json.loads((tmp_path / "settings.json").read_text())["tools"]
     assert "task_control" not in migrated             # retired -> dropped
-    assert migrated["todo_list"] == {"user_edit": 1}  # user config preserved
+    assert migrated["todo_list"] == {"enabled": True, "mcp": False, "user_edit": 1}
     assert migrated["code_executor"]["include"] == ["shell_executor"]  # narrowed
     assert migrated["code_executor"]["implementation"] == "python_env"  # new default added
 

--- a/webui/backend/tests/test_todo_config.py
+++ b/webui/backend/tests/test_todo_config.py
@@ -1,0 +1,99 @@
+"""Session plans remain local tools when settings omit the MCP flag."""
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from app.backends.ms_agent.bootstrap import _seed_tools_settings
+from app.backends.ms_agent.config import build_agent
+from ms_agent.config import Config
+from ms_agent.project import ProjectManager, SessionManager
+from ms_agent.tools.mcp_client import MCPClient
+from ms_agent.tools.tool_manager import ToolManager
+from ms_agent.ui.events import RecordingSink
+from omegaconf import OmegaConf
+
+
+@pytest.mark.parametrize("todo,import_after_start", [
+    (None, False), ({}, False),
+    ({"auto_render_md": False}, False),
+    ({"mcp": False}, False), ({"enabled": False}, False),
+    pytest.param(None, True, id="external-import-after-startup"),
+])
+def test_session_todo_stays_builtin(
+    tmp_path, monkeypatch, todo, import_after_start,
+):
+    monkeypatch.setenv("MS_AGENT_HOME", str(tmp_path))
+    settings = {"llm": {"provider": "openai", "model": "unused", "api_key": "unused"}}
+    if todo is not None:
+        settings["tools"] = {"todo_list": todo}
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps(settings))
+    _seed_tools_settings(str(tmp_path))
+    if import_after_start:
+        # Deployment imports replace the file without going through the SDK.
+        monkeypatch.setenv("OPENAI_API_KEY", "unused")
+        settings_path.write_text(json.dumps(settings))
+        assert "tools" not in json.loads(settings_path.read_text())
+
+    project = ProjectManager(base_dir=str(tmp_path)).create(
+        name="Session plans", memory_enabled=False,
+    )
+    sessions = SessionManager(project)
+    agents = [
+        build_agent(project, sessions.create(), event_sink=RecordingSink(),
+                    input_source=None, mcp_config={})
+        for _ in range(2)
+    ]
+
+    async def check():
+        for index, agent in enumerate(agents):
+            cfg = agent.config
+            assert cfg.tools.todo_list.mcp is False
+            for key, value in (todo or {}).items():
+                assert cfg.tools.todo_list[key] == value
+            assert "todo_list" not in Config.convert_mcp_servers_to_json(cfg)["mcpServers"]
+            # Exercise the real connection path that used to raise ValueError.
+            client = MCPClient(config=cfg, mcp_config=agent.mcp_config)
+            try:
+                await client.connect()
+                assert "todo_list" not in client.sessions
+            finally:
+                await client.cleanup()
+
+            # Only load the tool under test; unrelated default tools can need
+            # optional dependencies or credentials.
+            tool_config = OmegaConf.create({
+                "output_dir": project.path,
+                "tools": {"todo_list": OmegaConf.to_container(cfg.tools.todo_list)},
+            })
+            manager = ToolManager(tool_config)
+            try:
+                await manager.connect()
+                tools = await manager.get_tools()
+                server_names = {entry["server_name"] for entry in tools}
+                if (todo or {}).get("enabled") is False:
+                    assert "todo_list" not in server_names
+                    continue
+                assert "todo_list" in server_names
+                tool = next(t for t in manager.extra_tools if t.SERVER_NAME == "todo_list")
+                result = json.loads(await tool.todo_write(todos=[{
+                    "id": "one", "content": f"session-{index}", "status": "pending",
+                }]))
+                assert result["status"] == "ok"
+                plan = json.loads(Path(cfg.tools.todo_list.plan_filename).read_text())
+                assert plan["todos"][0]["content"] == f"session-{index}"
+            finally:
+                await manager.cleanup()
+
+    asyncio.run(check())
+    paths = [Path(agent.config.tools.todo_list.plan_filename) for agent in agents]
+    assert paths[0] != paths[1]
+    if (todo or {}).get("enabled") is not False:
+        assert json.loads(paths[0].read_text())["todos"][0]["content"] == "session-0"
+    persisted = json.loads(settings_path.read_text())["tools"]["todo_list"]
+    assert persisted["mcp"] is False
+    assert persisted["enabled"] is ((todo or {}).get("enabled") is not False)
+    assert "plan_filename" not in persisted  # session paths never become global
+    assert "plan_md_filename" not in persisted

--- a/webui/backend/tests/test_tool_defaults.py
+++ b/webui/backend/tests/test_tool_defaults.py
@@ -1,0 +1,157 @@
+"""External settings replacements retain a valid, visible WebUI tool scope."""
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from omegaconf import OmegaConf
+
+from app.backends.ms_agent.bootstrap import _seed_tools_settings
+from app.backends.ms_agent.config import build_agent
+from app.backends.ms_agent.defaults import DEFAULT_TOOLS
+from app.backends.ms_agent.tool_settings import ensure_tool_settings
+from ms_agent.config import Config
+from ms_agent.project import ProjectManager, SessionManager
+from ms_agent.tools.tool_manager import ToolManager
+from ms_agent.ui.events import RecordingSink
+
+
+def prepare(tmp_path, monkeypatch, tools=None):
+    monkeypatch.setenv("MS_AGENT_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "unused")
+    settings = {"llm": {"provider": "openai", "model": "unused", "api_key": "unused"}}
+    if tools is not None:
+        settings["tools"] = tools
+    (tmp_path / "settings.json").write_text(json.dumps(settings))
+    project = ProjectManager(base_dir=str(tmp_path)).create(name="Import", memory_enabled=False)
+    return project, SessionManager(project).create()
+
+
+def build(project, session):
+    return build_agent(project, session, event_sink=RecordingSink(), input_source=None, mcp_config={})
+
+
+def replace_settings(tmp_path, **fields):
+    """Simulate the deployment service, including its whole-file replacement."""
+    data = {"llm": {"provider": "openai", "model": "unused", "api_key": "unused"}, **fields}
+    path = tmp_path / "settings.json"
+    incoming = tmp_path / "external.json"
+    incoming.write_text(json.dumps(data))
+    incoming.replace(path)
+    return path
+
+
+@pytest.mark.parametrize("seed,import_template", [(False, False), (True, True), (False, True)])
+def test_default_tool_scope_without_persisted_defaults(tmp_path, monkeypatch, seed, import_template):
+    project, session = prepare(tmp_path, monkeypatch)
+    if seed:
+        _seed_tools_settings(str(tmp_path))
+        # Also cover external deployment services that still replace this file.
+        (tmp_path / "settings.json").write_text(json.dumps({
+            "llm": {"provider": "openai", "model": "unused"}}))
+    if import_template:
+        replace_settings(tmp_path, tools={})
+    cfg = build(project, session).config
+    for name, params in DEFAULT_TOOLS.items():
+        for key, value in params.items():
+            assert cfg.tools[name][key] == value
+    assert not Config.convert_mcp_servers_to_json(cfg)["mcpServers"]
+    assert list(cfg.tools.code_executor.include) == ["shell_executor"]
+    assert "task_control" not in cfg.tools
+    persisted = json.loads((tmp_path / "settings.json").read_text())["tools"]
+    assert persisted == DEFAULT_TOOLS
+    assert all(tool["enabled"] is True for tool in persisted.values())
+
+
+def test_partial_and_repeated_import_respects_all_four_switches(tmp_path, monkeypatch):
+    project, session = prepare(tmp_path, monkeypatch, {
+        name: {"enabled": False} for name in DEFAULT_TOOLS})
+    _seed_tools_settings(str(tmp_path))
+    tools = {name: {"enabled": False} for name in DEFAULT_TOOLS}
+    tools["todo_list"]["auto_render_md"] = False
+    tools["file_system"]["exclude"] = ["write_file"]
+    replace_settings(tmp_path, tools=tools)
+    ensure_tool_settings(tmp_path)
+    before = (tmp_path / "settings.json").read_bytes()
+    replace_settings(tmp_path, tools=tools)
+    ensure_tool_settings(tmp_path)
+    assert (tmp_path / "settings.json").read_bytes() == before
+    cfg = build(project, session).config
+    assert all(cfg.tools[name].enabled is False for name in DEFAULT_TOOLS)
+    assert cfg.tools.todo_list.auto_render_md is False
+    assert "include" not in cfg.tools.file_system
+    assert list(cfg.tools.file_system.exclude) == ["write_file"]
+    manager = ToolManager(cfg)
+    assert not {t.SERVER_NAME for t in manager.extra_tools} & set(DEFAULT_TOOLS)
+    _seed_tools_settings(str(tmp_path))  # restart must not re-enable anything
+    assert (tmp_path / "settings.json").read_bytes() == before
+
+
+def test_project_tool_settings_override_imported_template(tmp_path, monkeypatch):
+    project, session = prepare(tmp_path, monkeypatch)
+    replace_settings(tmp_path, tools={"todo_list": {"enabled": True},
+                                     "file_system": {"include": ["read_file"]}})
+    patch = Path(project.path) / ".ms_agent" / "config.yaml"
+    patch.parent.mkdir(exist_ok=True)
+    patch.write_text("tools:\n  todo_list:\n    enabled: false\n  file_system:\n    exclude: [write_file]\n")
+    cfg = build(project, session).config
+    assert cfg.tools.todo_list.enabled is False
+    assert cfg.tools.todo_list.mcp is False
+    assert "include" not in cfg.tools.file_system
+    assert list(cfg.tools.file_system.exclude) == ["write_file"]
+    persisted = json.loads((tmp_path / "settings.json").read_text())["tools"]
+    assert persisted["todo_list"]["enabled"] is True
+    assert persisted["file_system"]["include"] == ["read_file"]
+    assert "exclude" not in persisted["file_system"]
+
+
+def test_null_project_tool_is_reported_before_mcp_connection(tmp_path, monkeypatch):
+    project, session = prepare(tmp_path, monkeypatch)
+    path = Path(project.path) / ".ms_agent" / "config.yaml"
+    path.parent.mkdir(exist_ok=True)
+    path.write_text("tools:\n  todo_list: null\n")
+    with pytest.raises(ValueError, match=r"tools.todo_list.*enabled: false"):
+        build(project, session)
+
+
+def test_runtime_reloads_import_on_next_idle_turn(tmp_path, monkeypatch):
+    from app.backends.ms_agent import runtime
+    project, session = prepare(tmp_path, monkeypatch)
+
+    class Runtime:
+        def __init__(self, project, session, mcp):
+            self.turn_lock = asyncio.Lock()
+            self.run_task = SimpleNamespace(done=lambda: False)
+            self.model_key = model_link.active_model()
+            self.mcp_fingerprint = runtime._mcp_fingerprint(project)
+            self.settings_fingerprint = runtime._settings_fingerprint(project)
+            self.needs_rebuild = False
+            self.closed = False
+        def touch(self):
+            pass
+        async def aclose(self):
+            self.closed = True
+
+    from app.backends.ms_agent import model_link
+    monkeypatch.setattr(model_link, "active_model", lambda: ("openai", "unused"))
+    monkeypatch.setattr(runtime, "SessionRuntime", Runtime)
+    registry = runtime.RuntimeRegistry()
+    monkeypatch.setattr(registry, "_ensure_sweeper", lambda: None)
+    async def no_mcp(_project):
+        return {}
+    monkeypatch.setattr(registry, "_resolve_mcp", no_mcp)
+
+    async def check():
+        first = await registry.get(project, session)
+        await first.turn_lock.acquire()
+        replace_settings(tmp_path, tools={"todo_list": {"enabled": False}})
+        assert await registry.get(project, session) is first
+        assert not first.closed
+        assert json.loads((tmp_path / "settings.json").read_text())["tools"]["todo_list"] == {
+            "enabled": False, "mcp": False}
+        first.turn_lock.release()
+        second = await registry.get(project, session)
+        assert second is not first and first.closed
+        assert await registry.get(project, session) is second
+    asyncio.run(check())

--- a/webui/backend/tests/test_tool_settings.py
+++ b/webui/backend/tests/test_tool_settings.py
@@ -1,0 +1,121 @@
+"""Persist defaults after deployment writes, without rewriting user choices."""
+import json
+import stat
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.backends.errors import BadRequest
+from app.backends.ms_agent import tool_settings
+from app.backends.ms_agent.defaults import DEFAULT_TOOLS
+
+
+def write_settings(tmp_path, data):
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_missing_defaults_persist_without_session_or_credential_changes(tmp_path):
+    original = {
+        "llm": {"provider": "local", "model": "chat", "api_key": "local-test-key"},
+        "theme": "dark",
+        "tools": {
+            "todo_list": {"enabled": False, "auto_render_md": False},
+            "file_system": {"include": ["read_file"]},
+            "web_search": {"engine": "exa", "exa_api_key": "search-test-key"},
+            "custom_mcp": {"mcp": True, "command": "test-server", "enabled": False},
+        },
+    }
+    path = write_settings(tmp_path, original)
+    actual = tool_settings.ensure_tool_settings(tmp_path)
+    assert actual["llm"] == original["llm"]
+    assert actual["theme"] == "dark"
+    assert actual["tools"]["todo_list"] == {
+        "enabled": False, "mcp": False, "auto_render_md": False}
+    assert actual["tools"]["file_system"]["include"] == ["read_file"]
+    assert actual["tools"]["custom_mcp"] == original["tools"]["custom_mcp"]
+    assert actual["tools"]["web_search"]["exa_api_key"] == "search-test-key"
+    assert actual["tools"]["web_search"]["engine"] == "exa"
+    assert json.loads(path.read_text()) == actual
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    before, stamp = path.read_bytes(), path.stat().st_mtime_ns
+    assert tool_settings.ensure_tool_settings(tmp_path) == actual
+    assert path.read_bytes() == before
+    assert path.stat().st_mtime_ns == stamp
+
+
+@pytest.mark.parametrize("raw", [
+    "{broken", "[]", '{"tools":null}', '{"tools":{"todo_list":null}}',
+    '{"tools":{"code_executor":{"enabled":"false"}}}',
+    '{"tools":{"todo_list":{"mcp":true}}}',
+])
+def test_invalid_external_file_is_reported_and_left_untouched(tmp_path, raw):
+    path = tmp_path / "settings.json"
+    path.write_text(raw)
+    with pytest.raises(BadRequest) as caught:
+        tool_settings.ensure_tool_settings(tmp_path)
+    assert caught.value.status_code == 400
+    assert "settings" in caught.value.detail
+    assert path.read_text() == raw
+    assert not list(tmp_path.glob(".settings-*"))
+
+
+def test_external_replacement_does_not_restore_old_model_or_credentials(tmp_path):
+    path = write_settings(tmp_path, {"llm": {"api_key": "old-test-key"},
+                                    "tools": {"todo_list": {"enabled": False}}})
+    tool_settings.ensure_tool_settings(tmp_path)
+    path.write_text('{"llm":{"provider":"new","model":"new-model"}}')
+    actual = tool_settings.ensure_tool_settings(tmp_path)
+    assert actual["llm"] == {"provider": "new", "model": "new-model"}
+    # The external writer deleted the previous switch; absence follows defaults.
+    assert actual["tools"] == DEFAULT_TOOLS
+    assert "old-test-key" not in path.read_text()
+
+
+def test_recheck_preserves_an_external_edit_during_normalization(tmp_path, monkeypatch):
+    path = write_settings(tmp_path, {"theme": "before"})
+    original_read = tool_settings._read
+    calls = 0
+
+    def concurrent_read(target):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            path.write_text('{"theme":"after","tools":{"todo_list":{"enabled":false}}}')
+        return original_read(target)
+
+    monkeypatch.setattr(tool_settings, "_read", concurrent_read)
+    actual = tool_settings.ensure_tool_settings(tmp_path)
+    assert actual["theme"] == "after"
+    assert actual["tools"]["todo_list"]["enabled"] is False
+    assert json.loads(path.read_text()) == actual
+    assert not list(tmp_path.glob(".settings-*"))
+
+
+@pytest.mark.parametrize("route", ["/api/agent-settings", "/api/search-settings"])
+def test_settings_api_reconciles_external_import_without_restart(tmp_path, monkeypatch, route):
+    from app.api import agent_settings, search
+    from app.core.envelope import register_exception_handlers
+
+    monkeypatch.setenv("MS_AGENT_HOME", str(tmp_path))
+    app = FastAPI()
+    register_exception_handlers(app)
+    app.include_router(agent_settings.router)
+    app.include_router(search.router)
+    client = TestClient(app)
+    path = write_settings(tmp_path, {"tools": {"web_search": {"enabled": False}}})
+    first = client.get(route)
+    assert first.status_code == 200
+    assert json.loads(path.read_text())["tools"]["web_search"]["enabled"] is False
+    # No SDK import hook or service restart: the next read completes this file.
+    path.write_text('{"llm":{"provider":"openai","model":"imported"}}')
+    second = client.get(route)
+    assert second.status_code == 200
+    assert json.loads(path.read_text())["tools"] == DEFAULT_TOOLS
+    path.write_text('{"tools":{"todo_list":null}}')
+    rejected = client.get(route)
+    assert rejected.status_code == 400
+    assert "enabled: false" in rejected.json()["message"]
+    assert json.loads(path.read_text())["tools"]["todo_list"] is None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

- Persist explicit WebUI tool defaults after external settings updates.
- Preserve tool switches and scoped overrides, and prevent built-in tools from being treated as MCP servers.
- Reload settings between turns while retaining conversation history.
- Validation: 643 SDK regression tests and 447 WebUI backend tests passed; verified 6 real conversation turns.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Run `pre-commit install` and `pre-commit run --all-files` before git commit, and passed lint check.
* [ ] Documentation reflects the changes where applicable
