### PR TITLE
fix: atomic file-state writes and full loader errors

### DIFF
--- a/ms_agent/agent/llm_agent.py
+++ b/ms_agent/agent/llm_agent.py
@@ -54,6 +54,7 @@ from ms_agent.ui.events import (ContentDelta, ContentEnd, ContextCompacted,
                                 TurnCompleted, UsageInfo)
 from ms_agent.utils import (async_retry, is_retryable_error, read_history,
                             save_history)
+from ms_agent.utils.atomic_file import atomic_write_json
 from ms_agent.utils.constants import DEFAULT_TAG, DEFAULT_USER
 from ms_agent.utils.logger import get_logger
 from ms_agent.utils.snapshot import take_snapshot
@@ -1686,16 +1687,11 @@ class LLMAgent(Agent):
         if path is None:
             return
         try:
-            tmp = path.with_suffix('.json.tmp')
-            tmp.write_text(
-                json.dumps({
+            atomic_write_json(
+                path, {
                     'version': 1,
                     'sources': surface
-                },
-                           ensure_ascii=False,
-                           indent=1),
-                encoding='utf-8')
-            tmp.replace(path)
+                }, indent=1)
         except OSError as e:
             logger.warning(f'[prompt-surface] sidecar save failed: {e}')
 

--- a/ms_agent/agent_hub/_cache.py
+++ b/ms_agent/agent_hub/_cache.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from ms_agent.utils.atomic_file import atomic_write_json
+
 __all__ = [
     'cache_dir',
     'log_file',
@@ -96,14 +98,4 @@ def load_sync_state(name: str) -> dict:
 
 def save_sync_state(name: str, remote_files: dict[str, str]) -> None:
     """Persist sync state to disk (atomic write)."""
-    path = sync_state_file(name)
-    tmp = path.with_suffix('.tmp')
-    payload = json.dumps(
-        {
-            'remote_files': remote_files,
-        },
-        ensure_ascii=False,
-        indent=2,
-    )
-    tmp.write_text(payload, encoding='utf-8')
-    tmp.replace(path)
+    atomic_write_json(sync_state_file(name), {'remote_files': remote_files})

--- a/ms_agent/config/model_settings.py
+++ b/ms_agent/config/model_settings.py
@@ -10,9 +10,10 @@ never clobbers the other settings.json sections (llm, personalization, ...).
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from ms_agent.utils.atomic_file import atomic_write_json
 
 
 class ModelSettingsManager:
@@ -34,11 +35,7 @@ class ModelSettingsManager:
             return {}
 
     def _save_raw(self, data: Dict[str, Any]) -> None:
-        self._dir.mkdir(parents=True, exist_ok=True)
-        tmp = self._path.with_suffix('.json.tmp')
-        with open(tmp, 'w', encoding='utf-8') as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        os.replace(tmp, self._path)
+        atomic_write_json(self._path, data)
 
     # -- providers --
 

--- a/ms_agent/config/skills_manager.py
+++ b/ms_agent/config/skills_manager.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from ms_agent.config.resolver import merge_skills_configs
+from ms_agent.utils.atomic_file import atomic_write_json
 
 SKILLS_FILE = 'skills.json'
 #: Live-tree directory name, shared by both scopes (``<global_dir>/skills``
@@ -281,10 +282,4 @@ class SkillsConfigManager:
 
     @staticmethod
     def _write(path: Path, data: Dict[str, Any]) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix('.tmp')
-        with open(tmp, 'w', encoding='utf-8') as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        # replace() is atomic and cross-platform; rename() raises on Windows
-        # when the destination already exists.
-        tmp.replace(path)
+        atomic_write_json(path, data)

--- a/ms_agent/cron/repository.py
+++ b/ms_agent/cron/repository.py
@@ -2,13 +2,12 @@
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from ms_agent.cron.types import CronJobSpec, CronJobState
+from ms_agent.utils.atomic_file import atomic_write_json
 
 
 class JsonJobRepository:
@@ -31,15 +30,7 @@ class JsonJobRepository:
         """Write data atomically: tmpfile -> fsync -> os.replace.
         Caller MUST hold self._lock.
         """
-        content = json.dumps(data, ensure_ascii=False, indent=2)
-        dir_path = str(self._path.parent)
-        fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix='.tmp')
-        try:
-            os.write(fd, content.encode('utf-8'))
-            os.fsync(fd)
-        finally:
-            os.close(fd)
-        os.replace(tmp_path, str(self._path))
+        atomic_write_json(self._path, data, fsync=True)
         self._last_mtime = self._path.stat().st_mtime
         self._cache = data
 

--- a/ms_agent/memory/unified/orchestrator.py
+++ b/ms_agent/memory/unified/orchestrator.py
@@ -34,7 +34,6 @@ import asyncio
 import hashlib
 import json
 import os
-import tempfile
 import time
 from dataclasses import fields
 from typing import Any, Dict, List, Optional, Set
@@ -44,6 +43,7 @@ from ms_agent.memory.base import Memory
 # Single canonical deserializer, shared with ContextAssembler. A second local
 # copy previously drifted and silently dropped `tool_call_id` / `name`.
 from ms_agent.session.context_assembler import _dicts_to_messages
+from ms_agent.utils.atomic_file import atomic_write_json
 from ms_agent.utils.logger import get_logger
 from .config import MemoryConfig
 from .protocols import RECALL_BLOCK_MARKER, MemoryBackend, MemoryEntry
@@ -413,12 +413,12 @@ class MemoryOrchestrator(Memory):
                 seen.discard(stale)
             self._ledger_order = self._ledger_order[-_LEDGER_MAX:]
         try:
-            os.makedirs(str(self.mem_config.base_dir), exist_ok=True)
-            fd, tmp = tempfile.mkstemp(
-                dir=str(self.mem_config.base_dir), suffix='.tmp')
-            with os.fdopen(fd, 'w', encoding='utf-8') as fh:
-                json.dump({'version': 1, 'hashes': self._ledger_order}, fh)
-            os.replace(tmp, self._ledger_path())
+            atomic_write_json(
+                self._ledger_path(), {
+                    'version': 1,
+                    'hashes': self._ledger_order
+                },
+                indent=None)
         except OSError as e:  # pragma: no cover - bookkeeping never breaks
             logger.warning(f'[orchestrator] ingest ledger write failed: {e}')
 

--- a/ms_agent/memory/unified/storage/facts_storage.py
+++ b/ms_agent/memory/unified/storage/facts_storage.py
@@ -5,12 +5,11 @@ Supports confidence-based eviction, deduplication, and atomic writes.
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ms_agent.utils.atomic_file import atomic_write_json
 from ms_agent.utils.logger import get_logger
 from ..config import MemoryConfig
 from ..protocols import MemoryEntry
@@ -229,16 +228,7 @@ class FactsStorage:
         return default
 
     def _save(self, data: Dict[str, Any]) -> None:
-        self.facts_path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=self.facts_path.parent, suffix='.tmp')
-        try:
-            with os.fdopen(fd, 'w', encoding='utf-8') as f:
-                json.dump(data, f, ensure_ascii=False, indent=2)
-            os.replace(tmp, self.facts_path)
-        except Exception:
-            if os.path.exists(tmp):
-                os.unlink(tmp)
-            raise
+        atomic_write_json(self.facts_path, data)
         self._cache = data
 
     def invalidate_cache(self) -> None:

--- a/ms_agent/memory/unified/storage/file_storage.py
+++ b/ms_agent/memory/unified/storage/file_storage.py
@@ -3,13 +3,12 @@ character budget, and entry-level add / replace / remove operations.
 """
 from __future__ import annotations
 
-import os
-import tempfile
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ms_agent.utils.atomic_file import atomic_write_text
 from ms_agent.utils.logger import get_logger
 from ..config import MemoryConfig
 from ..protocols import MemoryEntry
@@ -188,16 +187,7 @@ class FileMemoryStorage:
         return content
 
     def _write(self, content: str) -> None:
-        self.memory_path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=self.memory_path.parent, suffix='.tmp')
-        try:
-            with os.fdopen(fd, 'w', encoding='utf-8') as f:
-                f.write(content)
-            os.replace(tmp, self.memory_path)
-        except Exception:
-            if os.path.exists(tmp):
-                os.unlink(tmp)
-            raise
+        atomic_write_text(self.memory_path, content)
         self._content_cache = content
         try:
             st = self.memory_path.stat()

--- a/ms_agent/personalization/profile.py
+++ b/ms_agent/personalization/profile.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from ms_agent.utils.atomic_file import atomic_write_text
+
 PROFILE_FILENAME = 'profile.md'
 
 
@@ -37,9 +39,4 @@ class ProfileManager:
         return self._path.read_text(encoding='utf-8')
 
     def write(self, content: str) -> None:
-        self._dir.mkdir(parents=True, exist_ok=True)
-        tmp = self._path.with_suffix('.tmp')
-        tmp.write_text(content, encoding='utf-8')
-        # replace() is atomic and cross-platform; rename() raises on Windows
-        # when the destination already exists.
-        tmp.replace(self._path)
+        atomic_write_text(self._path, content)

--- a/ms_agent/personalization/settings.py
+++ b/ms_agent/personalization/settings.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from ms_agent.personalization.types import PersonalizationConfig
+from ms_agent.utils.atomic_file import atomic_write_json
 
 SETTINGS_FILE = 'settings.json'
 SECTION_KEY = 'personalization'
@@ -57,10 +58,4 @@ class PersonalizationSettings:
             return {}
 
     def _write_full(self, data: Dict[str, Any]) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self._path.with_suffix('.tmp')
-        with open(tmp, 'w', encoding='utf-8') as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        # replace() is atomic and cross-platform; rename() raises on Windows
-        # when the destination already exists.
-        tmp.replace(self._path)
+        atomic_write_json(self._path, data)

--- a/ms_agent/plugins/config_manager.py
+++ b/ms_agent/plugins/config_manager.py
@@ -6,6 +6,7 @@ from threading import Lock
 from typing import Literal
 
 from ms_agent.plugins.types import PluginRecord
+from ms_agent.utils.atomic_file import atomic_write_json
 
 PluginScope = Literal['global', 'project', 'merged']
 PLUGIN_FILE = 'plugins.json'
@@ -142,12 +143,8 @@ class PluginConfigManager:
         records: list[PluginRecord],
     ) -> None:
         path = self._path_for_scope(scope)
-        path.parent.mkdir(parents=True, exist_ok=True)
         payload = {'plugins': [record.to_dict() for record in records]}
-        tmp = path.with_suffix('.tmp')
-        with open(tmp, 'w', encoding='utf-8') as f:
-            json.dump(payload, f, indent=2, ensure_ascii=False)
-        tmp.rename(path)
+        atomic_write_json(path, payload)
 
     @staticmethod
     def _read_json(path: Path) -> dict:

--- a/ms_agent/plugins/user_config.py
+++ b/ms_agent/plugins/user_config.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from ms_agent.utils.atomic_file import atomic_write_json
+
 _ALLOWED_TYPES = frozenset(
     {'string', 'boolean', 'number', 'integer', 'array', 'object'})
 
@@ -88,13 +90,7 @@ def save_user_config(
     errors = validate_values(schema, values)
     if errors:
         raise UserConfigError('; '.join(errors))
-    path = Path(data_dir)
-    path.mkdir(parents=True, exist_ok=True)
-    config_path = path / 'config.json'
-    tmp = config_path.with_suffix('.tmp')
-    with open(tmp, 'w', encoding='utf-8') as f:
-        json.dump(values, f, indent=2, ensure_ascii=False)
-    tmp.rename(config_path)
+    atomic_write_json(Path(data_dir) / 'config.json', values)
     return values
 
 

--- a/ms_agent/project/store.py
+++ b/ms_agent/project/store.py
@@ -4,9 +4,12 @@ import json
 from pathlib import Path
 from typing import Any
 
+from ms_agent.utils.atomic_file import atomic_write_json
+
 
 class JSONFileStore:
-    """Atomic JSON file read/write. Writes to .tmp then renames to prevent corruption."""
+    """Atomic JSON file read/write. Writes to a temp file then renames to
+    prevent corruption."""
 
     def __init__(self, path: str | Path) -> None:
         self._path = Path(path)
@@ -21,10 +24,4 @@ class JSONFileStore:
             return json.load(f)
 
     def write(self, data: dict[str, Any]) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self._path.with_suffix('.tmp')
-        with open(tmp, 'w', encoding='utf-8') as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        # replace() is atomic and cross-platform; rename() raises on Windows
-        # when the destination already exists.
-        tmp.replace(self._path)
+        atomic_write_json(self._path, data)

--- a/ms_agent/prompting/workspace_files.py
+++ b/ms_agent/prompting/workspace_files.py
@@ -32,6 +32,7 @@ from typing import Dict, Optional, Tuple
 
 from ms_agent.prompting.builtin import (HOME_FILE_TEMPLATES, TEMPLATE_VERSION)
 from ms_agent.project.paths import global_home, local_internal_dir
+from ms_agent.utils.atomic_file import atomic_write_text
 from ms_agent.utils.logger import get_logger
 
 logger = get_logger()
@@ -122,13 +123,6 @@ def _capped(body: str, path: Path) -> str:
     return body[:MAX_FILE_CHARS] + '\n\n[...truncated: file exceeds limit...]'
 
 
-def _atomic_write(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(path.name + '.tmp')
-    tmp.write_text(text, encoding='utf-8')
-    tmp.replace(path)
-
-
 # ── sidecar bookkeeping ──────────────────────────────────────────────────────
 
 
@@ -149,7 +143,8 @@ def _load_sidecar(home: Path, name: str) -> Optional[dict]:
 
 def _save_sidecar(home: Path, name: str, data: dict) -> None:
     try:
-        _atomic_write(_sidecar_path(home, name), json.dumps(data, indent=1))
+        atomic_write_text(
+            _sidecar_path(home, name), json.dumps(data, indent=1))
     except OSError as e:  # sidecar failures must never break the agent
         logger.warning(f'[workspace_files] cannot write sidecar for {name}: {e}')
 
@@ -164,7 +159,7 @@ def _ensure_one(home: Path, name: str, template: str) -> None:
         if sidecar is not None:
             return  # user deleted it — respect the deletion, never re-seed
         try:
-            _atomic_write(path, template)
+            atomic_write_text(path, template)
         except OSError as e:
             logger.warning(f'[workspace_files] cannot materialize {name}: {e}')
             return
@@ -181,8 +176,8 @@ def _ensure_one(home: Path, name: str, template: str) -> None:
             and sidecar.get('template_version', 0) < TEMPLATE_VERSION
             and _sha256(_read_raw(path)) == sidecar.get('sha256')):
         try:
-            _atomic_write(path.with_name(name + '.bak'), _read_raw(path))
-            _atomic_write(path, template)
+            atomic_write_text(path.with_name(name + '.bak'), _read_raw(path))
+            atomic_write_text(path, template)
         except OSError as e:
             logger.warning(f'[workspace_files] cannot upgrade {name}: {e}')
             return
@@ -223,8 +218,8 @@ def _rebuild_legacy_profile(home: Path) -> None:
     if raw.strip():
         rebuilt += '\n' + raw.strip() + '\n'
     try:
-        _atomic_write(target.with_name('PROFILE.md.bak'), raw)
-        _atomic_write(target, rebuilt)
+        atomic_write_text(target.with_name('PROFILE.md.bak'), raw)
+        atomic_write_text(target, rebuilt)
         # On case-sensitive filesystems the legacy lowercase file is a distinct
         # entry; drop it (its content lives in the .bak and in the new file).
         # On case-insensitive filesystems (macOS/Windows default) they are the
@@ -413,7 +408,7 @@ def read_home_file(name: str) -> str:
 def write_home_file(name: str, text: str) -> None:
     """Atomic write of a home workspace file. The mtime bump makes the next
     agent round pick the change up through the content compare."""
-    _atomic_write(global_home() / name, text)
+    atomic_write_text(global_home() / name, text)
 
 
 #: AGENTS.md has no managed block; the same splitter degrades to (R0, '', R2).

--- a/ms_agent/session/session_log.py
+++ b/ms_agent/session/session_log.py
@@ -40,6 +40,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ms_agent.utils.atomic_file import atomic_write_json
+
 
 class SessionLog:
     """Append-only JSONL session log — the source of truth for message history."""
@@ -518,12 +520,7 @@ class SessionLog:
 
     def _write_meta(self, meta: Dict[str, Any]) -> None:
         """Atomically persist the sidecar (write temp + os.replace)."""
-        tmp = self._meta_path.parent / (self._meta_path.name + '.tmp')
-        with open(tmp, 'w', encoding='utf-8') as f:
-            f.write(json.dumps(meta, ensure_ascii=False, indent=2))
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp, self._meta_path)
+        atomic_write_json(self._meta_path, meta, fsync=True)
         self._metadata = meta
 
     def _read_legacy_header(self) -> Optional[Dict[str, Any]]:

--- a/ms_agent/utils/atomic_file.py
+++ b/ms_agent/utils/atomic_file.py
@@ -1,0 +1,59 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Whole-file writes via a per-writer temp file plus rename.
+
+A reader sees either the whole old file or the whole new one. Writers are not
+serialized: the last rename wins, so a caller that needs an atomic
+read-modify-write still has to lock.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Union
+
+
+def atomic_write_text(path: Union[str, Path],
+                      text: str,
+                      *,
+                      encoding: str = 'utf-8',
+                      fsync: bool = False) -> None:
+    """Replace what is at ``path`` with ``text`` in one indivisible step.
+
+    Creates the parent directory if it is missing. Set ``fsync`` to flush to
+    the device before the rename.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Same directory, so the rename cannot cross filesystems; hidden and
+    # unique, so scans and watchers ignore it.
+    fd, tmp = tempfile.mkstemp(
+        dir=path.parent, prefix=f'.{path.name}.', suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w', encoding=encoding) as f:
+            f.write(text)
+            if fsync:
+                f.flush()
+                os.fsync(f.fileno())
+        # replace(), not rename(): rename() fails on Windows if path exists.
+        os.replace(tmp, path)
+    except BaseException:
+        with suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def atomic_write_json(path: Union[str, Path],
+                      data: Any,
+                      *,
+                      indent: Union[int, None] = 2,
+                      ensure_ascii: bool = False,
+                      fsync: bool = False) -> None:
+    """:func:`atomic_write_text` for JSON."""
+    # Serialized first, so an unencodable value leaves no temp file behind.
+    atomic_write_text(
+        path,
+        json.dumps(data, ensure_ascii=ensure_ascii, indent=indent),
+        fsync=fsync)

--- a/tests/personalization/test_profile.py
+++ b/tests/personalization/test_profile.py
@@ -50,5 +50,6 @@ class TestProfileManager:
 
     def test_write_atomic_no_partial_file(self, manager):
         manager.write('complete content')
-        tmp_file = manager.path.with_suffix('.tmp')
-        assert not tmp_file.exists()
+        # Temp names are unique per writer now, so check for any leftover.
+        left = [p.name for p in manager.path.parent.iterdir()]
+        assert left == ['profile.md']

--- a/tests/project/test_manager.py
+++ b/tests/project/test_manager.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 from ms_agent.project.manager import ProjectManager
 from ms_agent.project.types import DEFAULT_PROJECT_ID, Project
@@ -13,6 +15,35 @@ class TestProjectManager:
         assert default is not None
         assert default.id == DEFAULT_PROJECT_ID
         assert default.name == 'Default'
+
+    def test_concurrent_managers_can_create_the_default_project(
+            self, tmp_path):
+        # A first visit does this from several requests at once: the WebUI
+        # builds a manager per request and construction creates the default
+        # project when missing.
+        home = tmp_path / 'home'
+        callers = 6
+        failures: list[BaseException] = []
+        names: list[str] = []
+        start = threading.Barrier(callers)
+
+        def visit() -> None:
+            start.wait()
+            try:
+                names.append(
+                    ProjectManager(
+                        base_dir=str(home)).get_default_project().name)
+            except BaseException as exc:  # noqa: B902 - reported verbatim
+                failures.append(exc)
+
+        threads = [threading.Thread(target=visit) for _ in range(callers)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not failures, f'{len(failures)} failed: {failures[:3]}'
+        assert names == ['Default'] * callers
 
     def test_create_and_get(self, pm):
         project = pm.create(name='Test Project')

--- a/tests/project/test_store.py
+++ b/tests/project/test_store.py
@@ -1,4 +1,6 @@
 import json
+import threading
+
 import pytest
 from ms_agent.project.store import JSONFileStore
 
@@ -27,7 +29,42 @@ class TestJSONFileStore:
         store = JSONFileStore(tmp_path / 'test.json')
         store.write({'a': 1})
         assert not (tmp_path / 'test.tmp').exists()
+        # Temp names are unique per writer now, so check for any leftover.
+        assert [p.name for p in tmp_path.iterdir()] == ['test.json']
         assert (tmp_path / 'test.json').exists()
+
+    def test_concurrent_writes_neither_fail_nor_corrupt(self, tmp_path):
+        store = JSONFileStore(tmp_path / 'project.json')
+        writers = 6
+        payloads = {i: {'id': f'w{i}', 'pad': str(i) * 100000}
+                    for i in range(writers)}
+        failures: list[BaseException] = []
+        reads: list[str] = []
+        start = threading.Barrier(writers)
+
+        def hammer(i: int) -> None:
+            start.wait()
+            for _ in range(20):
+                try:
+                    store.write(payloads[i])
+                    got = store.read()
+                    assert got in payloads.values(), 'mixed content'
+                    reads.append(got['id'])
+                except BaseException as exc:  # noqa: B902 - reported verbatim
+                    failures.append(exc)
+
+        threads = [threading.Thread(target=hammer, args=(i,))
+                   for i in range(writers)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not failures, f'{len(failures)} failed: {failures[:3]}'
+        assert len(reads) == writers * 20
+        assert json.loads((tmp_path / 'project.json').read_text(
+            encoding='utf-8')) in payloads.values()
+        assert sorted(p.name for p in tmp_path.iterdir()) == ['project.json']
 
     def test_creates_parent_dirs(self, tmp_path):
         store = JSONFileStore(tmp_path / 'nested' / 'deep' / 'test.json')

--- a/tests/utils/test_atomic_file.py
+++ b/tests/utils/test_atomic_file.py
@@ -1,0 +1,78 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Atomic whole-file writes: no torn content, no lost rename, no leftovers."""
+import json
+import threading
+
+import pytest
+from ms_agent.utils.atomic_file import atomic_write_json, atomic_write_text
+
+
+def test_replaces_existing_content(tmp_path):
+    path = tmp_path / 'a.txt'
+    path.write_text('old', encoding='utf-8')
+    atomic_write_text(path, 'new')
+    assert path.read_text(encoding='utf-8') == 'new'
+    assert [p.name for p in tmp_path.iterdir()] == ['a.txt']
+
+
+def test_creates_missing_parents(tmp_path):
+    path = tmp_path / 'deep' / 'nested' / 'a.json'
+    atomic_write_json(path, {'a': 1})
+    assert json.loads(path.read_text(encoding='utf-8')) == {'a': 1}
+
+
+def test_fsync_writes_the_same_bytes(tmp_path):
+    path = tmp_path / 'durable.json'
+    atomic_write_json(path, {'a': 1}, fsync=True)
+    assert json.loads(path.read_text(encoding='utf-8')) == {'a': 1}
+    assert [p.name for p in tmp_path.iterdir()] == ['durable.json']
+
+
+def test_a_failed_write_leaves_neither_a_temp_file_nor_damage(tmp_path):
+    path = tmp_path / 'a.json'
+    atomic_write_json(path, {'good': True})
+
+    class Unserializable:
+        pass
+
+    with pytest.raises(TypeError):
+        atomic_write_json(path, {'bad': Unserializable()})
+
+    assert json.loads(path.read_text(encoding='utf-8')) == {'good': True}
+    assert [p.name for p in tmp_path.iterdir()] == ['a.json']
+
+
+def test_concurrent_writers_neither_fail_nor_corrupt(tmp_path):
+    # Payloads are large so a torn write would span many buffer writes.
+    path = tmp_path / 'shared.json'
+    writers = 6
+    payloads = {i: {'id': f'w{i}', 'pad': str(i) * 100000}
+                for i in range(writers)}
+    failures: list[BaseException] = []
+    reads = 0
+    lock = threading.Lock()
+    start = threading.Barrier(writers)
+
+    def hammer(i: int) -> None:
+        nonlocal reads
+        start.wait()
+        for _ in range(20):
+            try:
+                atomic_write_json(path, payloads[i])
+                got = json.loads(path.read_text(encoding='utf-8'))
+                assert got in payloads.values(), 'mixed content'
+                with lock:
+                    reads += 1
+            except BaseException as exc:  # noqa: B902 - reported verbatim
+                failures.append(exc)
+
+    threads = [threading.Thread(target=hammer, args=(i,))
+               for i in range(writers)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not failures, f'{len(failures)} failed: {failures[:3]}'
+    assert reads == writers * 20
+    assert [p.name for p in tmp_path.iterdir()] == ['shared.json']

--- a/webui/frontend/app/components/common/ErrorState.tsx
+++ b/webui/frontend/app/components/common/ErrorState.tsx
@@ -4,8 +4,8 @@ import errorDark from '~/assets/images/error-dark.png'
 import { useTheme } from '~/lib/theme'
 
 interface Props {
-  /** Big headline — the HTTP status code, or the error's own name when a
-   * client-side exception has no status. Omitted when neither exists. */
+  /** Big headline — the HTTP status code, or a generic phrase when a client-side
+   * exception has no status. Omitted when neither exists. */
   code?: string
   /** What failed, as reported by the server. */
   description: string

--- a/webui/frontend/app/layouts/app.tsx
+++ b/webui/frontend/app/layouts/app.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-router'
 import { IconButton } from '~/components/common/IconButton'
 import { Sidebar } from '~/components/layout/Sidebar'
-import { api } from '~/lib/api'
+import { api, orThrow } from '~/lib/api'
 import { useOnMcpSkillChanged } from '~/lib/events'
 import { recordLastAppRoute } from '~/lib/lastAppRoute'
 import { useModelChanged } from '~/lib/modelChanged'
@@ -34,6 +34,8 @@ const MD = '(min-width: 768px)'
 // resolving it per Composer mount re-asked the same question on every session
 // switch and flashed the "search not configured" pill in a beat late.
 export async function loader() {
+  // `orThrow` wraps the whole batch: any failure takes the app shell down, and
+  // a raw ApiError loses its class and status across the SSR boundary.
   const [
     projects,
     sessions,
@@ -43,16 +45,18 @@ export async function loader() {
     globalMcps,
     globalSkills,
     searchSettings
-  ] = await Promise.all([
-    api.listProjects(),
-    api.listSessions(),
-    api.listProviders(),
-    api.listModels(),
-    api.getAgentSettings(),
-    api.listMcps('global'),
-    api.listSkills('global'),
-    api.getSearchSettings()
-  ])
+  ] = await orThrow(
+    Promise.all([
+      api.listProjects(),
+      api.listSessions(),
+      api.listProviders(),
+      api.listModels(),
+      api.getAgentSettings(),
+      api.listMcps('global'),
+      api.listSkills('global'),
+      api.getSearchSettings()
+    ])
+  )
 
   return {
     projects,

--- a/webui/frontend/app/lib/api.ts
+++ b/webui/frontend/app/lib/api.ts
@@ -671,6 +671,17 @@ export const api = {
     json<{ running: string[] }>('/api/presence', { method: 'POST' })
 }
 
+/** Status a loader failure reaches the error page as.
+ *
+ * `Response` rejects anything outside 200-599, and an `ApiError` may carry no
+ * HTTP status (0 when the backend is unreachable) or a 2xx for a body-declared
+ * rejection. 502 stands for "no answer from the backend"; the error page turns
+ * it back into the network message. */
+function errorPageStatus(status: number): number {
+  if (status === 0) return 502
+  return status >= 400 && status <= 599 ? status : 500
+}
+
 /**
  * Turn an API failure inside a route loader into a thrown `Response`.
  *
@@ -678,14 +689,15 @@ export const api = {
  * loader error to the client as a plain Error, dropping both the class and the
  * `status`. The error page would then render 404 on the server and "unexpected
  * error" after hydration — a visible downgrade. A thrown Response carries its
- * status across intact, so both sides agree.
+ * status across intact, so both sides agree. Every server-side loader must go
+ * through here, `Promise.all` batches included.
  */
 export async function orThrow<T>(promise: Promise<T>): Promise<T> {
   try {
     return await promise
   } catch (err) {
     if (err instanceof ApiError)
-      throw new Response(err.message, { status: err.status })
+      throw new Response(err.message, { status: errorPageStatus(err.status) })
     throw err
   }
 }

--- a/webui/frontend/app/lib/locales/en.json
+++ b/webui/frontend/app/lib/locales/en.json
@@ -495,6 +495,7 @@
   "errors": {
     "requestFailed": "Request failed",
     "network": "Network error — please check your connection",
+    "unexpected": "Something went wrong",
     "backHome": "Back to home"
   },
   "pageTitle": {

--- a/webui/frontend/app/lib/locales/zh.json
+++ b/webui/frontend/app/lib/locales/zh.json
@@ -495,6 +495,7 @@
   "errors": {
     "requestFailed": "请求失败",
     "network": "网络错误，请检查您的网络连接",
+    "unexpected": "出错了",
     "backHome": "回到首页"
   },
   "pageTitle": {

--- a/webui/frontend/app/root.tsx
+++ b/webui/frontend/app/root.tsx
@@ -258,29 +258,27 @@ export function ErrorBoundary() {
   const error = useRouteError()
   const { t } = useT()
   const routeError = isRouteErrorResponse(error)
-  // A loader that let an API failure propagate carries the real HTTP status on
-  // the ApiError — without reading it, a missing project/session would show no
-  // status at all when it is plainly a 404.
-  const apiStatus = error instanceof ApiError ? error.status : undefined
-  const status = routeError ? error.status : apiStatus
-  // The status code IS the headline. A client-side exception carries no status,
-  // so it falls back to the error's OWN name (`TypeError`) rather than a phrase
-  // we made up — same principle as the description below.
-  const code = status
-    ? String(status)
-    : error instanceof Error
-      ? error.name
-      : undefined
+  // Read nothing off the error object but its message: a server-rendered error
+  // arrives here as a plain `Error`, so `status` and the class are gone and
+  // reading them broke hydration. Loaders carry status via `orThrow` instead.
+  const status = routeError ? error.status : undefined
+  // No status means a client-side exception; its own name is unavailable (see
+  // above), so use a fixed phrase and let the message explain.
+  const code = status ? String(status) : t.errors.unexpected
   // The server's own message is the explanation — it is the only text that knows
   // what actually failed. Inventing a per-status sentence here would replace
   // "project not found" with something vaguer.
-  const description = routeError
+  const reported = routeError
     ? typeof error.data === 'string' && error.data
       ? error.data
       : error.statusText
     : error instanceof Error
       ? error.message
       : String(error ?? '')
+  // Some failures carry no words at all (backend never answered, or an empty
+  // gateway body), which left the headline over an empty paragraph.
+  const description =
+    reported || (status === 502 ? t.errors.network : t.errors.requestFailed)
 
   return (
     <ErrorState

--- a/webui/frontend/app/routes/settings/models.tsx
+++ b/webui/frontend/app/routes/settings/models.tsx
@@ -518,13 +518,18 @@ function ProviderDetail({
           ))
         )}
 
-        {/* Add model button - inline with model items */}
-        <div
-          className="flex cursor-pointer items-center justify-center gap-1.5 rounded-[10px] border border-dashed border-msa-line-1 px-4 py-[18px] text-sm text-msa-text-brand1 transition-colors hover:border-msa-line-3"
-          onClick={onAddModel}
-        >
-          <AddIcon className="h-4 w-4" />
-          <span>{t.modelsAdmin.addModel}</span>
+        {/* Sticky instead of antd Affix: no scroll target to wire up, and a
+            short list never scrolls so it just sits inline. The wrapper pulls
+            the pane background over the list gap above it (-mt-3 + pt-3 cancel
+            out) so rows slide out of sight behind the button. */}
+        <div className="sticky bottom-0 -mt-3 bg-msa-fill-0 pt-3">
+          <div
+            className="flex cursor-pointer items-center justify-center gap-1.5 rounded-[10px] border border-dashed border-msa-line-1 px-4 py-[18px] text-sm text-msa-text-brand1 transition-colors hover:border-msa-line-3"
+            onClick={onAddModel}
+          >
+            <AddIcon className="h-4 w-4" />
+            <span>{t.modelsAdmin.addModel}</span>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Change Summary

- Add a shared `atomic_write_text` / `atomic_write_json` helper and move the
  SDK's file-state writers onto it, with a unique temp name per writer so
  concurrent writes cannot clobber each other.
- Route the WebUI app-shell loader through `orThrow` so a loader failure keeps
  its HTTP status across SSR, and always render a status and a message.
- Keep the add-model button in view on the provider pane.

## Related issue number

N/A

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Relevant Python tests and frontend type checking pass
* [x] Documentation reflects the changes where applicable
